### PR TITLE
Use Composition API instead of Options API for components

### DIFF
--- a/components/AreaDropdown.vue
+++ b/components/AreaDropdown.vue
@@ -14,43 +14,27 @@
 <script setup lang="ts">
 import { useStore } from '~/stores/store'
 const store = useStore()
-</script>
 
-<script lang="ts">
-export default {
-  data() {
-    return {
-      selectedValue: undefined,
-    }
-  },
-  computed: {
-    selectedArea() {
-      const store = useStore()
-      return store.selectedArea
-    },
-  },
-  methods: {
-    select(name) {
-      this.selectedValue = name
-      const store = useStore()
-      store.$patch({
-        selected: this.selected,
-      })
-    },
-  },
-  watch: {
-    selectedValue: function (value) {
-      const store = useStore()
-      store.$patch({
-        selected: value,
-      })
-      if (this.selectedArea) {
-        store.fetchResultGeom()
-      }
-    },
-    selectedArea: function (value) {
-      this.selectedValue = value
-    },
-  },
+let selectedValue = ref(undefined)
+
+const selectedArea = computed(() => store.selectedArea)
+
+const select = name => {
+  store.$patch({
+    selected: name,
+  })
 }
+
+watch(selectedValue, async value => {
+  store.$patch({
+    selected: value,
+  })
+  if (selectedArea.value) {
+    store.fetchResultGeom()
+  }
+})
+
+watch(selectedArea, async value => {
+  selectedValue.value = value
+})
 </script>

--- a/components/BackButton.vue
+++ b/components/BackButton.vue
@@ -4,18 +4,11 @@
 
 <script setup lang="ts">
 import { useStore } from '~/stores/store'
-</script>
+const store = useStore()
 
-<script lang="ts">
-export default {
-  methods: {
-    select(name) {
-      this.selected = name
-      const store = useStore()
-      store.$patch({
-        selected: this.selected,
-      })
-    },
-  },
+const select = name => {
+  store.$patch({
+    selected: name,
+  })
 }
 </script>

--- a/components/Chart.vue
+++ b/components/Chart.vue
@@ -19,134 +19,128 @@
 
 <script setup lang="ts">
 import { useStore } from '~/stores/store'
-</script>
+const store = useStore()
 
-<script lang="ts">
-let fmoLabels = {
+let fmoSelection = ref('nofmo')
+
+const fmoLabels = {
   nofmo: 'FMO #1',
   fmo: 'FMO #2',
   altfmo: 'FMO #3',
 }
-let modelLabels = {
+
+const modelLabels = {
   ccsm: 'NCAR-CCSM4 (RCP 8.5)',
   gfdl: 'GFDL-CM3 (RCP 8.5)',
 }
-export default {
-  data() {
-    return {
-      fmoOptions: [
-        {
-          label: fmoLabels['nofmo'],
-          value: 'nofmo',
-        },
-        {
-          label: fmoLabels['fmo'],
-          value: 'fmo',
-        },
-        {
-          label: fmoLabels['altfmo'],
-          value: 'altfmo',
-        },
-      ],
-      fmoSelection: 'nofmo',
-    }
-  },
-  methods: {
-    renderPlot() {
-      const store = useStore()
-      let lowOffset =
-        store.chartData['historical']['neutral'] -
-        store.chartData['historical']['low']
-      let highOffset =
-        store.chartData['historical']['high'] -
-        store.chartData['historical']['neutral']
-      let traces = [
-        {
-          type: 'scatter',
-          name: 'CRU TS 4.0',
-          x: [1],
-          y: [store.chartData['historical']['neutral']],
-          error_y: {
-            type: 'data',
-            array: [highOffset],
-            arrayminus: [lowOffset],
-            visible: true,
-          },
-        },
-      ]
-      let modelSymbols = {
-        ccsm: 'circle',
-        gfdl: 'square',
-      }
-      Object.keys(store.chartData[this.fmoSelection]).forEach(model => {
-        traces.push({
-          type: 'scatter',
-          mode: 'markers',
-          name: modelLabels[model],
-          x: [1, 2, 3],
-          y: store.chartData[this.fmoSelection][model],
-          marker: {
-            symbol: modelSymbols[model],
-          },
-        })
-      })
-      if (store.selected) {
-        const { $Plotly } = useNuxtApp()
-        $Plotly.newPlot(
-          'chart',
-          traces,
-          {
-            autosize: true,
-            height: 475,
-            margin: {
-              l: 50,
-              r: 50,
-              b: 75,
-              t: 120,
-              pad: 5,
-            },
-            title: {
-              text:
-                'Riparian Fire Vulnerability<br />' +
-                store.selected +
-                '<br />' +
-                fmoLabels[this.fmoSelection],
-            },
-            xaxis: {
-              tickvals: [0, 1, 2, 3],
-              ticktext: ['', '2002-2018', '2038-2047', '2068-2077'],
-              dtick: 1,
-            },
-          },
-          {
-            responsive: true,
-            displayModeBar: true,
-            displaylogo: false,
-            modeBarButtonsToRemove: [
-              'zoom2d',
-              'pan2d',
-              'select2d',
-              'lasso2d',
-              'zoomIn2d',
-              'zoomOut2d',
-              'autoScale2d',
-              'resetScale2d',
-            ],
-          }
-        )
-      }
-    },
-  },
-  watch: {
-    fmoSelection: function () {
-      this.renderPlot()
-    },
-  },
-  mounted() {
-    this.renderPlot()
 
-    // Trigger Plotly responsiveness to fill available width.
-    window.dispatchEvent(new Event('resize'))
+const fmoOptions = [
+  {
+    label: fmoLabels['nofmo'],
+    value: 'nofmo',
   },
+  {
+    label: fmoLabels['fmo'],
+    value: 'fmo',
+  },
+  {
+    label: fmoLabels['altfmo'],
+    value: 'altfmo',
+  },
+]
+
+const renderPlot = () => {
+  let lowOffset =
+    store.chartData['historical']['neutral'] -
+    store.chartData['historical']['low']
+  let highOffset =
+    store.chartData['historical']['high'] -
+    store.chartData['historical']['neutral']
+  let traces = [
+    {
+      type: 'scatter',
+      name: 'CRU TS 4.0',
+      x: [1],
+      y: [store.chartData['historical']['neutral']],
+      error_y: {
+        type: 'data',
+        array: [highOffset],
+        arrayminus: [lowOffset],
+        visible: true,
+      },
+    },
+  ]
+  const modelSymbols = {
+    ccsm: 'circle',
+    gfdl: 'square',
+  }
+  Object.keys(store.chartData[fmoSelection.value]).forEach(model => {
+    traces.push({
+      type: 'scatter',
+      mode: 'markers',
+      name: modelLabels[model],
+      x: [1, 2, 3],
+      y: store.chartData[fmoSelection.value][model],
+      marker: {
+        symbol: modelSymbols[model],
+      },
+    })
+  })
+  if (store.selected) {
+    const { $Plotly } = useNuxtApp()
+    $Plotly.newPlot(
+      'chart',
+      traces,
+      {
+        autosize: true,
+        height: 475,
+        margin: {
+          l: 50,
+          r: 50,
+          b: 75,
+          t: 120,
+          pad: 5,
+        },
+        title: {
+          text:
+            'Riparian Fire Vulnerability<br />' +
+            store.selected +
+            '<br />' +
+            fmoLabels[fmoSelection.value],
+        },
+        xaxis: {
+          tickvals: [0, 1, 2, 3],
+          ticktext: ['', '2002-2018', '2038-2047', '2068-2077'],
+          dtick: 1,
+        },
+      },
+      {
+        responsive: true,
+        displayModeBar: true,
+        displaylogo: false,
+        modeBarButtonsToRemove: [
+          'zoom2d',
+          'pan2d',
+          'select2d',
+          'lasso2d',
+          'zoomIn2d',
+          'zoomOut2d',
+          'autoScale2d',
+          'resetScale2d',
+        ],
+      }
+    )
+  }
 }
+
+watch(fmoSelection, async () => {
+  renderPlot()
+})
+
+onMounted(() => {
+  renderPlot()
+
+  // Trigger Plotly responsiveness to fill available width.
+  window.dispatchEvent(new Event('resize'))
+})
 </script>

--- a/components/IntersectingAreas.vue
+++ b/components/IntersectingAreas.vue
@@ -10,18 +10,10 @@
 <script setup lang="ts">
 import { useStore } from '~/stores/store'
 const store = useStore()
-</script>
 
-<script lang="ts">
-export default {
-  methods: {
-    select(name) {
-      this.selected = name
-      const store = useStore()
-      store.$patch({
-        selected: this.selected,
-      })
-    },
-  },
+const select = name => {
+  store.$patch({
+    selected: name,
+  })
 }
 </script>

--- a/components/Map.vue
+++ b/components/Map.vue
@@ -12,105 +12,88 @@
 <script setup lang="ts">
 import { useStore } from '~/stores/store'
 const store = useStore()
-</script>
 
-<script lang="ts">
-export default {
-  data() {
-    return {
-      map: undefined,
-      mapFeatures: [],
-      resultMapFeature: undefined,
+const map = ref(undefined)
+const mapFeatures = ref([])
+const resultMapFeature = ref(undefined)
+
+const selectedArea = computed(() => store.selectedArea)
+
+const updateMap = () => {
+  // Clear layer(s)
+  if (!selectedArea.value && !resultMapFeature.value != undefined) {
+    resultMapFeature.value.clearLayers()
+    resultMapFeature.value = undefined
+  }
+  mapFeatures.value.forEach(feature => {
+    feature.clearLayers()
+  })
+
+  // Add layer(s)
+  if (!selectedArea.value) {
+    mapFeatures.value = []
+    store.matchedGeoms.forEach(polygon => {
+      mapFeatures.value.push(L.geoJSON(polygon).addTo(map.value))
+    })
+    map.value.setView([64.8, -146.4], 3)
+  }
+  if (selectedArea.value) {
+    store.fetchResultGeom().then(() => {
+      resultMapFeature.value = L.geoJSON(store.reportGeom).addTo(map.value)
+      map.value.fitBounds(resultMapFeature.value.getBounds())
+    })
+  }
+}
+
+watch(selectedArea, async () => {
+  updateMap()
+})
+
+onMounted(() => {
+  const proj = new L.Proj.CRS(
+    'EPSG:3338',
+    '+proj=aea +lat_1=55 +lat_2=65 +lat_0=50 +lon_0=-154 +x_0=0 +y_0=0 +ellps=GRS80 +datum=NAD83 +units=m +no_defs',
+    {
+      resolutions: [4096, 2048, 1024, 512, 256, 128, 64],
     }
-  },
-  computed: {
-    selectedArea() {
-      const store = useStore()
-      return store.selectedArea
-    },
-  },
-  updated() {
-    this.map.invalidateSize()
-  },
-  watch: {
-    selectedArea: {
-      handler: function () {
-        this.updateMap()
-      },
-    },
-  },
-  methods: {
-    updateMap() {
-      const store = useStore()
+  )
 
-      // Clear layer(s)
-      if (!this.selectedArea && !this.resultMapFeature != undefined) {
-        this.resultMapFeature.clearLayers()
-        this.resultMapFeature = undefined
-      }
-      this.mapFeatures.forEach(feature => {
+  if (map.value == undefined) {
+    map.value = L.map('map', {
+      zoom: 3,
+      minZoom: 1,
+      maxZoom: 6,
+      zoomSnap: 0.1,
+      center: [64.8, -146.4],
+      scrollWheelZoom: false,
+      crs: proj,
+      layers: new L.tileLayer.wms('https://gs.mapventure.org/geoserver/wms', {
+        transparent: true,
+        srs: 'EPSG:3338',
+        format: 'image/png',
+        version: '1.3.0',
+        layers: [
+          'atlas_mapproxy:alaska_osm_retina',
+          'shadow_mask:iem_with_ak_aleutians_symmetric_difference',
+        ],
+      }),
+    })
+  }
+
+  map.value.on('click', e => {
+    var popLocation = e.latlng
+    store.fetchIntersectingAreas(e.latlng.lat, e.latlng.lng).then(() => {
+      mapFeatures.value.forEach(feature => {
         feature.clearLayers()
       })
-
-      // Add layer(s)
-      if (!this.selectedArea) {
-        this.mapFeatures = []
-        store.matchedGeoms.forEach(polygon => {
-          this.mapFeatures.push(L.geoJSON(polygon).addTo(this.map))
-        })
-        this.map.setView([64.8, -146.4], 3)
-      }
-      if (this.selectedArea) {
-        store.fetchResultGeom().then(() => {
-          this.resultMapFeature = L.geoJSON(store.reportGeom).addTo(this.map)
-          this.map.fitBounds(this.resultMapFeature.getBounds())
-        })
-      }
-    },
-  },
-  mounted() {
-    var proj = new L.Proj.CRS(
-      'EPSG:3338',
-      '+proj=aea +lat_1=55 +lat_2=65 +lat_0=50 +lon_0=-154 +x_0=0 +y_0=0 +ellps=GRS80 +datum=NAD83 +units=m +no_defs',
-      {
-        resolutions: [4096, 2048, 1024, 512, 256, 128, 64],
-      }
-    )
-
-    if (this.map == undefined) {
-      this.map = L.map('map', {
-        zoom: 3,
-        minZoom: 1,
-        maxZoom: 6,
-        zoomSnap: 0.1,
-        center: [64.8, -146.4],
-        scrollWheelZoom: false,
-        crs: proj,
-        layers: new L.tileLayer.wms('https://gs.mapventure.org/geoserver/wms', {
-          transparent: true,
-          srs: 'EPSG:3338',
-          format: 'image/png',
-          version: '1.3.0',
-          layers: [
-            'atlas_mapproxy:alaska_osm_retina',
-            'shadow_mask:iem_with_ak_aleutians_symmetric_difference',
-          ],
-        }),
-      })
-    }
-
-    const store = useStore()
-    this.map.on('click', e => {
-      var popLocation = e.latlng
-      store.fetchIntersectingAreas(e.latlng.lat, e.latlng.lng).then(() => {
-        this.mapFeatures.forEach(feature => {
-          feature.clearLayers()
-        })
-        store.matchedGeoms.forEach(polygon => {
-          this.mapFeatures.push(L.geoJSON(polygon).addTo(this.map))
-        })
+      store.matchedGeoms.forEach(polygon => {
+        mapFeatures.value.push(L.geoJSON(polygon).addTo(map.value))
       })
     })
-  },
-}
+  })
+})
+
+onMounted(() => {
+  map.value.invalidateSize()
+})
 </script>


### PR DESCRIPTION
Closes #7.

This PR refactors all components (but not the store, that's a separate issue) to use the Composition API instead of Options API. All functionality should remain exactly the same. So, to test, make sure the web app works the same way as before!