### PR TITLE
Use Composition API instead of Options API for store

### DIFF
--- a/stores/store.ts
+++ b/stores/store.ts
@@ -1,176 +1,188 @@
 import { defineStore } from 'pinia'
 import areaData from '~/assets/data'
 
-export const useStore = defineStore('store', {
-  state: () => ({
-    areas: undefined,
-    intersectingAreas: undefined,
-    selected: undefined,
-    resultGeom: undefined,
-  }),
+export const useStore = defineStore('store', () => {
+  const areas = ref([])
+  const intersectingAreas = ref(undefined)
+  const selected = ref(undefined)
+  const resultGeom = ref(undefined)
 
-  getters: {
-    areaOptions: state => state.areas,
-    matchedAreaNames: state => {
-      let names = []
-      if (state.intersectingAreas != undefined) {
-        state.intersectingAreas.forEach(area => {
-          names.push(area.properties['AOI_Name_'])
-        })
+  const fetchAreaOptions = async () => {
+    try {
+      let groups = {}
+
+      let groupLookup = {
+        DOD: 'Department of Defense (DOD) Lands',
+        ADFG: 'ADF&G Game Management Units',
+        FIRE: 'AFS Fire Management Units',
+        HUC: 'Hydrologic Unit Code (HUC)',
+        PARK: 'Park and Conservation Units',
       }
-      return names
-    },
-    matchedGeoms: state => {
-      let geoms = []
-      if (state.intersectingAreas != undefined) {
-        state.intersectingAreas.forEach(area => {
-          geoms.push(area.geometry)
-        })
-      }
-      return geoms
-    },
-    selectedArea: state => {
-      return state.selected
-    },
-    reportGeom: state => {
-      return state.resultGeom
-    },
-    chartData: state => {
-      let matchedData = undefined
-      let chartData = {}
-      if (state.selected) {
-        areaData.forEach(obj => {
-          if (obj['AOI_Name_'] == state.selected) {
-            matchedData = structuredClone(obj)
-            delete matchedData['AOI_Name_']
-          }
-        })
-        Object.keys(matchedData).forEach(key => {
-          if (key.includes('ccsm_') || key.includes('gfdl_')) {
-            let [model, fmo, index] = key.split('_')
-            if (!chartData.hasOwnProperty(fmo)) {
-              chartData[fmo] = {
-                ccsm: [null],
-                gfdl: [null],
-              }
+
+      const runtimeConfig = useRuntimeConfig()
+      let geoserverUrl = runtimeConfig.public.geoserverUrl
+      let response = await $fetch(geoserverUrl)
+      if (response != undefined) {
+        response.features.forEach(area => {
+          let category = area.properties['Category']
+          if (!groups.hasOwnProperty(category)) {
+            groups[category] = {
+              type: 'group',
+              label: groupLookup[category],
+              key: category,
+              children: [],
             }
-            chartData[fmo][model].splice(index, 0, matchedData[key])
           }
+          groups[category]['children'].push({
+            label: area.properties['AOI_Name_'],
+            value: area.properties['AOI_Name_'],
+          })
         })
-        chartData['historical'] = {
-          low: matchedData['low_scenario'],
-          neutral: matchedData['neutral'],
-          high: matchedData['high_scenario'],
-        }
       }
-      return chartData
-    },
-    tableData: state => {
-      let matchedData = undefined
+      areas.value = []
+      Object.keys(groups).forEach(key => {
+        areas.value.push(groups[key])
+      })
+    } catch (error) {
+      console.log(error)
+    }
+  }
+
+  const fetchIntersectingAreas = async (lat, lon) => {
+    try {
+      let areas = []
+      const runtimeConfig = useRuntimeConfig()
+      let geoserverUrl =
+        runtimeConfig.public.geoserverUrl +
+        '&cql_filter=INTERSECTS(the_geom,POINT(' +
+        lon +
+        ' ' +
+        lat +
+        '))'
+      let response = await $fetch(geoserverUrl)
+      if (response != undefined) {
+        intersectingAreas.value = response.features
+      }
+    } catch (error) {
+      console.log(error)
+    }
+  }
+
+  const fetchResultGeom = async () => {
+    try {
+      const runtimeConfig = useRuntimeConfig()
+      let geoserverUrl =
+        runtimeConfig.public.geoserverUrl +
+        "&cql_filter=AOI_Name_='" +
+        selected.value +
+        "'"
+      let response = await $fetch(geoserverUrl)
+      if (response != undefined) {
+        resultGeom.value = response.features[0].geometry
+      }
+    } catch (error) {
+      console.log(error)
+    }
+  }
+
+  const areaOptions = computed(() => {
+    return areas.value
+  })
+
+  const matchedAreaNames = computed(() => {
+    let names = []
+    if (intersectingAreas.value != undefined) {
+      intersectingAreas.value.forEach(area => {
+        names.push(area.properties['AOI_Name_'])
+      })
+    }
+    return names
+  })
+
+  const matchedGeoms = computed(() => {
+    let geoms = []
+    if (intersectingAreas.value != undefined) {
+      intersectingAreas.value.forEach(area => {
+        geoms.push(area.geometry)
+      })
+    }
+    return geoms
+  })
+
+  const selectedArea = computed(() => {
+    return selected.value
+  })
+
+  const reportGeom = computed(() => {
+    return resultGeom.value
+  })
+
+  const chartData = computed(() => {
+    let matchedData = undefined
+    let chartData = {}
+    if (selected.value) {
       areaData.forEach(obj => {
-        if (obj['AOI_Name_'] == state.selected) {
+        if (obj['AOI_Name_'] == selected.value) {
           matchedData = structuredClone(obj)
           delete matchedData['AOI_Name_']
         }
       })
-      let tableData = {}
-      if (matchedData) {
-        Object.keys(matchedData).forEach(key => {
-          if (
-            !key.includes('ccsm_') &&
-            !key.includes('gfdl_') &&
-            !key.includes('_scenario') &&
-            !key.includes('neutral')
-          ) {
-            tableData[key] = matchedData[key]
-          }
-        })
-      }
-      return tableData
-    },
-  },
-  actions: {
-    async fetchAreaOptions() {
-      try {
-        let groups = {}
-
-        let groupLookup = {
-          DOD: 'Department of Defense (DOD) Lands',
-          ADFG: 'ADF&G Game Management Units',
-          FIRE: 'AFS Fire Management Units',
-          HUC: 'Hydrologic Unit Code (HUC)',
-          PARK: 'Park and Conservation Units',
-        }
-
-        const runtimeConfig = useRuntimeConfig()
-        let geoserverUrl = runtimeConfig.public.geoserverUrl
-        let response = await $fetch(geoserverUrl)
-        if (response != undefined) {
-          response.features.forEach(area => {
-            let category = area.properties['Category']
-            if (!groups.hasOwnProperty(category)) {
-              groups[category] = {
-                type: 'group',
-                label: groupLookup[category],
-                key: category,
-                children: [],
-              }
+      Object.keys(matchedData).forEach(key => {
+        if (key.includes('ccsm_') || key.includes('gfdl_')) {
+          let [model, fmo, index] = key.split('_')
+          if (!chartData.hasOwnProperty(fmo)) {
+            chartData[fmo] = {
+              ccsm: [null],
+              gfdl: [null],
             }
-            groups[category]['children'].push({
-              label: area.properties['AOI_Name_'],
-              value: area.properties['AOI_Name_'],
-            })
-          })
+          }
+          chartData[fmo][model].splice(index, 0, matchedData[key])
         }
-        let areas = []
-        Object.keys(groups).forEach(key => {
-          areas.push(groups[key])
-        })
-        this.$patch(state => {
-          state.areas = areas
-        })
-      } catch (error) {
-        console.log(error)
+      })
+      chartData['historical'] = {
+        low: matchedData['low_scenario'],
+        neutral: matchedData['neutral'],
+        high: matchedData['high_scenario'],
       }
-    },
-    async fetchIntersectingAreas(lat, lon) {
-      try {
-        let areas = []
-        const runtimeConfig = useRuntimeConfig()
-        let geoserverUrl =
-          runtimeConfig.public.geoserverUrl +
-          '&cql_filter=INTERSECTS(the_geom,POINT(' +
-          lon +
-          ' ' +
-          lat +
-          '))'
-        let response = await $fetch(geoserverUrl)
-        if (response != undefined) {
-          this.$patch(state => {
-            state.intersectingAreas = response.features
-          })
+    }
+    return chartData
+  })
+
+  const tableData = computed(() => {
+    let matchedData = undefined
+    areaData.forEach(obj => {
+      if (obj['AOI_Name_'] == selected.value) {
+        matchedData = structuredClone(obj)
+        delete matchedData['AOI_Name_']
+      }
+    })
+    let tableData = {}
+    if (matchedData) {
+      Object.keys(matchedData).forEach(key => {
+        if (
+          !key.includes('ccsm_') &&
+          !key.includes('gfdl_') &&
+          !key.includes('_scenario') &&
+          !key.includes('neutral')
+        ) {
+          tableData[key] = matchedData[key]
         }
-      } catch (error) {
-        console.log(error)
-      }
-    },
-    async fetchResultGeom() {
-      try {
-        const runtimeConfig = useRuntimeConfig()
-        let geoserverUrl =
-          runtimeConfig.public.geoserverUrl +
-          "&cql_filter=AOI_Name_='" +
-          this.selected +
-          "'"
-        let response = await $fetch(geoserverUrl)
-        if (response != undefined) {
-          this.$patch(state => {
-            state.resultGeom = response.features[0].geometry
-          })
-        }
-      } catch (error) {
-        console.log(error)
-      }
-    },
-  },
+      })
+    }
+    return tableData
+  })
+
+  return {
+    fetchAreaOptions,
+    fetchIntersectingAreas,
+    fetchResultGeom,
+    areaOptions,
+    matchedAreaNames,
+    matchedGeoms,
+    selected,
+    selectedArea,
+    reportGeom,
+    chartData,
+    tableData,
+  }
 })


### PR DESCRIPTION
Closes #5.

This PR refactors the `store.ts` file to use the Composition API instead of Options API. Refactoring of the components was done separately in PR #10. To test, make sure the web app works the same as it did before!