### PR TITLE
Omit unused polygon data during AOI dropdown menu population

### DIFF
--- a/stores/store.ts
+++ b/stores/store.ts
@@ -103,7 +103,9 @@ export const useStore = defineStore('store', {
         }
 
         const runtimeConfig = useRuntimeConfig()
-        let geoserverUrl = runtimeConfig.public.geoserverUrl
+        let geoserverUrl =
+          runtimeConfig.public.geoserverUrl +
+          '&PropertyName=(AOI_Name_,Category)'
         let response = await $fetch(geoserverUrl)
         if (response != undefined) {
           response.features.forEach(area => {


### PR DESCRIPTION
Closes #11.

This PR adds an extra GET parameter (`PropertyName=(AOI_Name_,Category)`) to the GeoServer request to fetch the names and categories of all AOIs, which is used to populate the dropdown menu. This GET parameter cherry picks the information we need without returning all of the polygon data along with it.

To test, everything should work the same as before. However, if you look at your browser's network developer tool, it will show that the size of this request has been reduced from 3.8mb to 4.3kb. Also, the AOI dropdown menu populates immediately instead of there being a ~1 second delay (depending on your internet speed).