### PR TITLE
Prevent polygon search functionality on report view and fix map zoom bug

### DIFF
--- a/components/Map.vue
+++ b/components/Map.vue
@@ -34,6 +34,7 @@ const updateMap = () => {
     mapFeatures.value = []
     store.matchedGeoms.forEach(polygon => {
       mapFeatures.value.push(L.geoJSON(polygon).addTo(map))
+      fitAllPolygons()
     })
   }
   if (selectedArea.value) {
@@ -79,20 +80,21 @@ onMounted(() => {
   }
   fitAllPolygons()
   map.on('click', e => {
-    var popLocation = e.latlng
-    store.fetchIntersectingAreas(e.latlng.lat, e.latlng.lng).then(() => {
-      mapFeatures.value.forEach(feature => {
-        feature.clearLayers()
+    if (!selectedArea.value) {
+      var popLocation = e.latlng
+      store.fetchIntersectingAreas(e.latlng.lat, e.latlng.lng).then(() => {
+        mapFeatures.value.forEach(feature => {
+          feature.clearLayers()
+        })
+        store.matchedGeoms.forEach(polygon => {
+          mapFeatures.value.push(L.geoJSON(polygon).addTo(map))
+        })
       })
-      store.matchedGeoms.forEach(polygon => {
-        mapFeatures.value.push(L.geoJSON(polygon).addTo(map))
-      })
-    })
+    }
   })
 })
 
 onUpdated(() => {
   map.invalidateSize()
-  fitAllPolygons()
 })
 </script>


### PR DESCRIPTION
Closes #15.

This PR disables the "click to find intersecting polygons" map functionality when the user is on the report (chart/table) view for a location. It also fixes a bug that was introduced during a previous PR merge. The map was not zooming back out when the user clicked the back button. Now it is.

To test:

1. Click the map to find intersecting polygons, then click one of the location links on the right side.
2. On the report page (with chart and table visible), make sure you cannot continue to click the map to find intersecting polygons.
3. Click the "Go Back" button, and verify that the map zooms back out to bounds appropriate to show all possible polygons. In other words, no polygons should extend past the bounds of the map, ever.