### PR TITLE
Stack charts at less-than-desktop resolutions, and increase map width on report page

### DIFF
--- a/assets/main.css
+++ b/assets/main.css
@@ -1,3 +1,9 @@
 .leaflet-container {
   cursor: pointer !important;
 }
+
+@media(max-width: 1024px) {
+  .container {
+    padding: 1.5rem;
+  }
+}

--- a/components/FishGrowthCharts.vue
+++ b/components/FishGrowthCharts.vue
@@ -24,10 +24,7 @@
   </div>
 </template>
 
-<style lange="scss" scoped>
-.metric-selector {
-  width: 300px;
-}
+<style lang="scss" scoped>
 .fish-growth-chart {
   @media (max-width: 1023px) {
     width: 100%;

--- a/components/FishGrowthCharts.vue
+++ b/components/FishGrowthCharts.vue
@@ -14,7 +14,6 @@
         </NSpace>
       </NRadioGroup>
     </div>
-    <div class="column is-half"></div>
   </div>
   <div class="is-clearfix">
     <div
@@ -30,7 +29,12 @@
   width: 300px;
 }
 .fish-growth-chart {
-  width: 50%;
+  @media (max-width: 1023px) {
+    width: 100%;
+  }
+  @media (min-width: 1024px) {
+    width: 50%;
+  }
 }
 </style>
 

--- a/components/HydroCharts.vue
+++ b/components/HydroCharts.vue
@@ -1,7 +1,7 @@
 <template>
   <h1 class="title">Hydrology</h1>
-  <div class="columns">
-    <div class="column is-half">
+  <div class="columns is-desktop">
+    <div class="column is-half-desktop">
       <p class="is-size-5 mb-2">Hydrology Statistics</p>
       <NSelect
         v-model:value="metricSelection"
@@ -10,7 +10,7 @@
         class="metric-selector"
       />
     </div>
-    <div class="column is-half">
+    <div class="column is-half-desktop">
       <NRadioGroup v-model:value="periodSelection" name="period-selector">
         <p class="is-size-5 mb-2">Hydrograph Period</p>
         <NSpace>
@@ -24,11 +24,11 @@
       </NRadioGroup>
     </div>
   </div>
-  <div class="columns" v-for="streamOrder in streamOrders">
-    <div class="column is-half">
+  <div class="columns is-desktop" v-for="streamOrder in streamOrders">
+    <div class="column is-half-desktop">
       <div v-bind:id="'hydro-stats-chart-' + streamOrder"></div>
     </div>
-    <div class="column is-half">
+    <div class="column is-half-desktop">
       <div v-bind:id="'hydrograph-chart-' + streamOrder"></div>
     </div>
   </div>

--- a/components/Map.vue
+++ b/components/Map.vue
@@ -45,6 +45,7 @@ const updateMap = () => {
 
   if (selectedArea.value == undefined) {
     fitAllPolygons()
+    map.invalidateSize()
   }
 }
 
@@ -95,7 +96,6 @@ onMounted(() => {
 })
 
 onUpdated(() => {
-  map.invalidateSize()
   fitAllPolygons()
 })
 </script>

--- a/components/Map.vue
+++ b/components/Map.vue
@@ -2,7 +2,7 @@
   <div id="map" />
 </template>
 
-<style scoped>
+<style lang="scss" scoped>
 #map {
   width: 100%;
   height: 500px;

--- a/components/StreamTempCharts.vue
+++ b/components/StreamTempCharts.vue
@@ -10,7 +10,6 @@
         class="metric-selector"
       />
     </div>
-    <div class="column is-half"></div>
   </div>
   <div class="is-clearfix">
     <div
@@ -26,7 +25,12 @@
   width: 300px;
 }
 .stream-temp-chart {
-  width: 50%;
+  @media (max-width: 1023px) {
+    width: 100%;
+  }
+  @media (min-width: 1024px) {
+    width: 50%;
+  }
 }
 </style>
 

--- a/components/StreamTempCharts.vue
+++ b/components/StreamTempCharts.vue
@@ -20,7 +20,7 @@
   </div>
 </template>
 
-<style lange="scss" scoped>
+<style lang="scss" scoped>
 .metric-selector {
   width: 300px;
 }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -39,12 +39,12 @@
 </template>
 
 <style lang="scss" scoped>
-  @media (min-width: 1024px) {
-    .section {
-      padding-left: 0;
-      padding-right: 0;
-    }
+@media (min-width: 1024px) {
+  .section {
+    padding-left: 0;
+    padding-right: 0;
   }
+}
 </style>
 
 <script setup lang="ts">

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -4,11 +4,11 @@
       <div v-show="store.selectedArea">
         <h1 class="title mb-5">{{ store.selectedArea }}</h1>
       </div>
-      <div class="columns mb-5">
-        <div class="column is-half">
+      <div class="columns">
+        <div class="column" :class="store.selectedArea ? 'is-full' : 'is-half'">
           <Map />
         </div>
-        <div class="column is-half">
+        <div class="column is-half" v-show="!store.selectedArea">
           <div v-show="!store.selectedArea">
             <AreaDropdown />
             <IntersectingAreas />
@@ -16,16 +16,13 @@
         </div>
       </div>
     </div>
-    <div v-show="store.selectedArea">
-      <hr />
+    <div v-show="store.selectedArea" class="section">
       <FishGrowthCharts
         v-if="store.selectedArea && store.hasArea('fishGrowth')"
       />
-      <hr />
       <FireImpactCharts
         v-if="store.selectedArea && store.hasArea('fireImpact')"
       />
-      <hr />
       <HydroCharts
         v-if="
           store.selectedArea &&
@@ -33,7 +30,6 @@
           store.hasArea('hydrograph')
         "
       />
-      <hr />
       <StreamTempCharts
         v-if="store.selectedArea && store.hasArea('streamTemp')"
       />
@@ -41,6 +37,15 @@
     </div>
   </div>
 </template>
+
+<style lang="scss" scoped>
+  @media (min-width: 1024px) {
+    .section {
+      padding-left: 0;
+      padding-right: 0;
+    }
+  }
+</style>
 
 <script setup lang="ts">
 import { useStore } from '~/stores/store'


### PR DESCRIPTION
Closes #31.
Closes #32.

The primary purpose of this PR is to stop placing charts side-by-side at widths lower than `1024px`, and stack all charts on top of each other instead.

Also, I attempted to make better use of the available space for the map at the top of the report page. In doing so I accidentally made the map take up the full width of the page, but I think it looks really good actually, especially since so many of the AOIs we are dealing with in this webapp tend to be more horizontal than vertical.

I also removed the `<hr />` dividers between sections since they seemed excessive after adding headings to each section in a previous PR.

To test, load a report for an AOI and try resizing your browser above and below `1024px` and make sure things look nice and the charts are readable.