### PR TITLE
Add year period to hydrograph chart titles

### DIFF
--- a/components/HydroCharts.vue
+++ b/components/HydroCharts.vue
@@ -276,7 +276,9 @@ const renderPlot = () => {
             text:
               'Hydrograph<br />' +
               store.selected +
-              '<br />Stream Order: ' +
+              '<br />Period: ' +
+              periodLabels[periodSelection.value] +
+              ', Stream Order: ' +
               streamOrder,
           },
           xaxis: {


### PR DESCRIPTION
Closes #30.

This PR simply adds the selected period (year range) to the hydrograph chart titles. To test, load the report page for an AOI that has hydrograph charts (on the right-hand side of the "Hydrology" section) and confirm that the hydrograph chart titles update with the selected year range.