### PR TITLE
Add padding around AOI polygon on report page

### DIFF
--- a/components/Map.vue
+++ b/components/Map.vue
@@ -39,7 +39,7 @@ const updateMap = () => {
   if (selectedArea.value) {
     store.fetchResultGeom().then(() => {
       resultMapFeature.value = L.geoJSON(store.reportGeom).addTo(map)
-      map.fitBounds(resultMapFeature.value.getBounds())
+      map.fitBounds(resultMapFeature.value.getBounds(), {padding: [50, 50]})
     })
   }
 


### PR DESCRIPTION
Closes #20.

This PR simply adds some padding around the selected AOI on the Leaflet map so the AOI boundary isn't so close to the edges of the map. To test, select an AOI and verify the AOI boundary has some room to breath (should be at least `50px` on each side).