### PR TITLE
Give Plotly downloads more descriptive file names

### DIFF
--- a/components/FireImpactCharts.vue
+++ b/components/FireImpactCharts.vue
@@ -242,6 +242,9 @@ const renderPlot = () => {
           'autoScale2d',
           'resetScale2d',
         ],
+        toImageButtonOptions: {
+          filename: 'riparian_fire_impact',
+        },
       }
     )
   }

--- a/components/FishGrowthCharts.vue
+++ b/components/FishGrowthCharts.vue
@@ -182,6 +182,9 @@ const renderPlot = () => {
             'autoScale2d',
             'resetScale2d',
           ],
+          toImageButtonOptions: {
+            filename: 'fish_growth',
+          },
         }
       )
     }

--- a/components/HydroCharts.vue
+++ b/components/HydroCharts.vue
@@ -312,6 +312,9 @@ const renderPlot = () => {
             'autoScale2d',
             'resetScale2d',
           ],
+          toImageButtonOptions: {
+            filename: 'hydrograph',
+          },
         }
       )
     }

--- a/components/HydroCharts.vue
+++ b/components/HydroCharts.vue
@@ -258,6 +258,11 @@ const renderPlot = () => {
             'autoScale2d',
             'resetScale2d',
           ],
+          toImageButtonOptions: {
+            filename: metricLabels[metricSelection.value]
+              .toLowerCase()
+              .replace(/ /g, '_'),
+          },
         }
       )
 

--- a/components/StreamTempCharts.vue
+++ b/components/StreamTempCharts.vue
@@ -194,6 +194,11 @@ const renderPlot = () => {
             'autoScale2d',
             'resetScale2d',
           ],
+          toImageButtonOptions: {
+            filename: metricLabels[metricSelection.value]
+              .toLowerCase()
+              .replace(/ /g, '_'),
+          },
         }
       )
     }


### PR DESCRIPTION
Closes #33.

This PR updates each Plotly chart to have a more descriptive filename when you click the camera icon to download the chart as a PNG. The file names now reflect the variable displayed on the chart.

For some charts this variable / file name are static (`fish_growth.png`, `riparian_fire_impact.png`, `hydrograph.png`).

The other charts are more dynamic and show whatever variable is selected from the dropdown menu, but the Plotly code is configured to use whatever variable is selected for the PNG file names after converting the variable name to lowercase with underscores.

To test, try download the Plotly PNG of many charts and variables and confirm that the file name reflects the variable displayed on the chart.