### PR TITLE
Add AOI polygon click, hover, and label effects to map, and add reset button

### DIFF
--- a/components/IntersectingAreas.vue
+++ b/components/IntersectingAreas.vue
@@ -6,6 +6,7 @@
         <a @click="select(areaName)">{{ areaName }}</a>
       </li>
     </ul>
+    <NButton @click="reset()" class="mt-3" v-if="store.matchedAreaNames.length > 0">Reset</NButton>
   </div>
 </template>
 
@@ -16,6 +17,12 @@ const store = useStore()
 const select = name => {
   store.$patch({
     selected: name,
+  })
+}
+
+const reset = () => {
+  store.$patch({
+    reset: true,
   })
 }
 </script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "dependencies": {
         "@pinia/nuxt": "^0.4.6",
+        "@turf/area": "^6.5.0",
         "bulma": "^0.9.4",
         "leaflet": "^1.9.3",
         "naive-ui": "^2.34.3",
@@ -1383,6 +1384,37 @@
       "integrity": "sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==",
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/@turf/area": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/area/-/area-6.5.0.tgz",
+      "integrity": "sha512-xCZdiuojokLbQ+29qR6qoMD89hv+JAgWjLrwSEWL+3JV8IXKeNFl6XkEJz9HGkVpnXvQKJoRz4/liT+8ZZ5Jyg==",
+      "dependencies": {
+        "@turf/helpers": "^6.5.0",
+        "@turf/meta": "^6.5.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/helpers": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.5.0.tgz",
+      "integrity": "sha512-VbI1dV5bLFzohYYdgqwikdMVpe7pJ9X3E+dlr425wa2/sMJqYDhTO++ec38/pcPvPE6oD9WEEeU3Xu3gza+VPw==",
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/meta": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.5.0.tgz",
+      "integrity": "sha512-RrArvtsV0vdsCBegoBtOalgdSOfkBrTJ07VkpiCnq/491W67hnMWmDu7e6Ztw0C3WldRYTXkg3SumfdzZxLBHA==",
+      "dependencies": {
+        "@turf/helpers": "^6.5.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
       }
     },
     "node_modules/@types/estree": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@pinia/nuxt": "^0.4.6",
+    "@turf/area": "^6.5.0",
     "bulma": "^0.9.4",
     "leaflet": "^1.9.3",
     "naive-ui": "^2.34.3",

--- a/plugins/turf.js
+++ b/plugins/turf.js
@@ -1,0 +1,9 @@
+import area from '@turf/area';
+
+export default defineNuxtPlugin(nuxtApp => {
+  return {
+    provide: {
+      turfArea: area,
+    },
+  }
+})

--- a/stores/store.ts
+++ b/stores/store.ts
@@ -19,6 +19,7 @@ export const useStore = defineStore('store', () => {
   const intersectingAreas = ref(undefined)
   const selected = ref(undefined)
   const resultGeom = ref(undefined)
+  const reset = ref(false)
 
   const fetchAreaOptions = async () => {
     try {
@@ -112,11 +113,11 @@ export const useStore = defineStore('store', () => {
     return names
   })
 
-  const matchedGeoms = computed(() => {
+  const matchedAreas = computed(() => {
     let geoms = []
     if (intersectingAreas.value != undefined) {
       intersectingAreas.value.forEach(area => {
-        geoms.push(area.geometry)
+        geoms.push(area)
       })
     }
     return geoms
@@ -181,8 +182,9 @@ export const useStore = defineStore('store', () => {
     fetchIntersectingAreas,
     fetchResultGeom,
     areaOptions,
+    intersectingAreas,
     matchedAreaNames,
-    matchedGeoms,
+    matchedAreas,
     selected,
     selectedArea,
     reportGeom,
@@ -192,5 +194,6 @@ export const useStore = defineStore('store', () => {
     hydrographData,
     hydroStatsData,
     streamTempData,
+    reset,
   }
 })


### PR DESCRIPTION
Closes #35.

The PR adds the ability to select an AOI by clicking a polygon on the map, as well as adding AOI labels and polygon highlighting on mouse hover, similar to NCR.

To test:

- Run `npm install` to install the new Turf.js dependency. Turf is used to calculate the area (size) of polygons to determine the order in which to add them to the map. This prevents large polygons from overlapping smaller polygons and blocking the hover & click effects of smaller polygons.
- Click the map to find a set of AOIs that intersect the point you clicked.
- Hover over the polygons that appear on the map. When you hover over a polygon, verify that the color changes to yellow and the AOI label is displayed.
- Click a polygon. This should load the "report view" for the AOI, the same as if you had selected the AOI any other way.
- Click the "Go Back" button at the bottom of the "report view" to return to the AOI selection screen.
- Click the "Reset" button to remove the intersecting AOIs from the map and AOI links from the right.
- Confirm that you can start the process over again. Click the map to find a new set of intersecting polygons.