### PR TITLE
Disable map click on report page

### DIFF
--- a/components/Map.vue
+++ b/components/Map.vue
@@ -102,13 +102,15 @@ onMounted(() => {
 
 const addMapHandlers = () => {
   map.on('click', e => {
-    layerGroup.addTo(map)
-    store.fetchIntersectingAreas(e.latlng.lat, e.latlng.lng).then(() => {
-      if (store.matchedAreas.length > 0) {
-        map.off('click')
-        addMatchedAreas()
-      }
-    })
+    if (!selectedArea.value) {
+      layerGroup.addTo(map)
+      store.fetchIntersectingAreas(e.latlng.lat, e.latlng.lng).then(() => {
+        if (store.matchedAreas.length > 0) {
+          map.off('click')
+          addMatchedAreas()
+        }
+      })
+    }
   })
 }
 

--- a/components/Map.vue
+++ b/components/Map.vue
@@ -92,6 +92,8 @@ onMounted(() => {
       minZoom: 4,
       zoomSnap: 0.1,
       maxBounds: maxBounds,
+      zoomControl: false,
+      dragging: false,
       scrollWheelZoom: false,
       layers: [baseLayer],
     })


### PR DESCRIPTION
Closes #15.

This PR disables the "click to find intersecting polygons" functionality on the report page. We already had a different PR open for this, but the code had changed a lot since then so this implements the same fix using the current code base. 

Without this change, after selecting an AOI and loading the "report" page for the AOI (with all the charts and stuff), clicking the map would continue to find and draw intersecting polygons, which was not appropriate for the report page.

To test, load the app, select an AOI, and while on the report page, try clicking the map both inside and outside the AOI's polygon boundary. If this PR works correctly, the map should ignore the clicks and not attempt to find additional intersecting polygons until you click the "Go Back" and "Reset" button.