### PR TITLE
Add a shadow mask to the map around combined extent of all AOIs

### DIFF
--- a/components/IntersectingAreas.vue
+++ b/components/IntersectingAreas.vue
@@ -1,6 +1,8 @@
 <template>
   <div class="content">
-    <p class="mb-5">Click the map to find areas of interest.</p>
+    <p class="mb-5">
+      Click the map within the highlighted region to find areas of interest.
+    </p>
     <ul class="list">
       <li v-for="areaName in store.matchedAreaNames" class="list-item">
         <a @click="select(areaName)">{{ areaName }}</a>

--- a/components/Map.vue
+++ b/components/Map.vue
@@ -21,6 +21,7 @@ const store = useStore()
 var map = undefined // Leaflet map object
 var maxBounds = undefined
 var layerGroup = new L.LayerGroup()
+var shadowMask = undefined
 
 const resultMapFeature = ref(undefined)
 const selectedArea = computed(() => store.selectedArea)
@@ -36,8 +37,10 @@ const updateMap = () => {
   // Restore intersecting polygons from previous click operation
   if (!selectedArea.value) {
     layerGroup.addTo(map)
+    map.addLayer(shadowMask)
   } else {
     map.removeLayer(layerGroup)
+    map.removeLayer(shadowMask)
   }
 
   if (selectedArea.value) {
@@ -87,15 +90,25 @@ onMounted(() => {
       baseLayer: true,
     }
   )
+
+  shadowMask = new L.tileLayer.wms('https://gs.mapventure.org/geoserver/wms', {
+    transparent: true,
+    format: 'image/png',
+    version: '1.3.0',
+    layers: ['fish_and_fire:AOI_v2_shadowmask'],
+  })
+
   if (map == undefined) {
     map = L.map('map', {
       minZoom: 4,
       zoomSnap: 0.1,
+      doubleClickZoom: false,
       maxBounds: maxBounds,
       scrollWheelZoom: false,
-      layers: [baseLayer],
+      layers: [baseLayer, shadowMask],
     })
   }
+
   fitAllPolygons()
   addMapHandlers()
 })


### PR DESCRIPTION
Closes #41.

This PR adds a shadow mask around the combined extent of all AOIs to indicate that the darker areas of the map are not clickable. I've also tweaked the instructions to tell users to click within the "highlighted region" and disabled double-click map zooming to avoid unnecessary frustration if these instructions are not clear.

To test, verify that you see a shadow mask around the clickable AOI area on the map when the app first loads.