### PR TITLE
Improvements to chart titles, word-wrapping, y-axis labels, and white space

### DIFF
--- a/components/FireImpactCharts.vue
+++ b/components/FireImpactCharts.vue
@@ -208,7 +208,7 @@ const renderPlot = () => {
         },
         title: {
           text:
-            'Riparian Fire Vulnerability<br />' +
+            '<b>Riparian fire vulnerability</b><br />' +
             store.selected +
             '<br />' +
             fmoLabels[fmoSelection.value] +

--- a/components/FishGrowthCharts.vue
+++ b/components/FishGrowthCharts.vue
@@ -37,6 +37,7 @@
 
 <script setup lang="ts">
 import { useStore } from '~/stores/store'
+import chartUtils from '~/utils/chartUtils'
 import { NRadioGroup, NRadio, NSpace } from 'naive-ui'
 const store = useStore()
 
@@ -136,6 +137,17 @@ const renderPlot = () => {
     if (store.selected) {
       const { $Plotly } = useNuxtApp()
 
+      let areaString = store.selected
+      areaString = chartUtils.wordwrapString(areaString)
+
+      let chartTitle =
+        '<b>Fish growth</b><br />' +
+        areaString +
+        '<br />' +
+        fmoLabels[fmoSelection.value] +
+        ', Stream Order: ' +
+        streamOrder
+
       // Create and populate each stream order chart with traces.
       $Plotly.newPlot(
         'fish-growth-chart-' + streamOrder,
@@ -144,17 +156,13 @@ const renderPlot = () => {
           autosize: true,
           height: 475,
           margin: {
+            t: chartUtils.topPadding(chartTitle),
             l: 75,
             r: 75,
           },
           title: {
-            text:
-              'Fish Growth<br />' +
-              store.selected +
-              '<br />' +
-              fmoLabels[fmoSelection.value] +
-              ', Stream Order: ' +
-              streamOrder,
+            text: chartTitle,
+            y: 0.95,
           },
           xaxis: {
             tickvals: [0, 1, 2, 3],

--- a/components/HydroCharts.vue
+++ b/components/HydroCharts.vue
@@ -36,6 +36,7 @@
 
 <script setup lang="ts">
 import { useStore } from '~/stores/store'
+import { NSelect, NRadioGroup, NRadio, NSpace } from 'naive-ui'
 import chartUtils from '~/utils/chartUtils'
 const store = useStore()
 

--- a/components/HydroCharts.vue
+++ b/components/HydroCharts.vue
@@ -34,15 +34,9 @@
   </div>
 </template>
 
-<style lang="scss" scoped>
-.metric-selector {
-  width: 300px;
-}
-</style>
-
 <script setup lang="ts">
 import { useStore } from '~/stores/store'
-import { NSelect, NRadioGroup, NRadio, NSpace } from 'naive-ui'
+import chartUtils from '~/utils/chartUtils'
 const store = useStore()
 
 let metricSelection = ref('mean_annual_flow')
@@ -54,25 +48,60 @@ const modelLabels = {
 }
 
 const metricLabels = {
-  mean_annual_flow: 'Mean Annual Flow',
-  LCV: 'LCV',
-  LSkew: 'LSkew',
-  LKurt: 'LKurt',
-  AR1: 'AR1',
-  Amplitude: 'Amplitude',
-  phase: 'phase',
-  WinterMean: 'WinterMean',
-  Spring2yr: 'Spring2yr',
-  Spring1pt5yr: 'Spring1pt5yr',
-  Spring99: 'Spring99',
-  Spring95: 'Spring95',
-  Channelflow: 'Channelflow',
-  CtrFlowMass: 'CtrFlowMass',
-  Summer95: 'Summer95',
-  Summer20p: 'Summer20p',
-  MeanSummer: 'MeanSummer',
-  Highlow: 'Highlow',
-  flow7q10: 'flow7q10',
+  mean_annual_flow: 'Mean annual flow',
+  MeanSummer: 'Mean summer flow',
+  WinterMean: 'Mean winter flow',
+  LCV: 'Coefficient of variation for the distribution of flow values',
+  LSkew: 'Skewness for the distribution of flow values',
+  LKurt: 'Kurtosis for the distribution of flow values',
+  AR1: 'Magnitude of maximum flow relative to mean',
+  Amplitude: 'AR1 correlation for entire continuous time series of flow values',
+  phase: 'Average day of year of maximum flow',
+  Spring2yr: 'Frequency of spring 2 year high flows',
+  Spring1pt5yr: 'Frequency of spring 1.5 year high flows',
+  Spring99: 'Number of days spring flows were in the top 1% of annual flows',
+  Spring95: 'Number of days spring flows were in the top 5% of annual flows',
+  Channelflow: 'Probability 1.5 year flow event would occur during a year',
+  CtrFlowMass: 'Center of timing of the mass of flow for an annual water year',
+  Summer95: 'Number of days summer flows were in the top 5% of annual flows',
+  Summer20p:
+    'Number of days summer flows were less than 20% of the mean annual flow',
+  Highlow:
+    'Annual 1.5 year high flow probability divided by the mean summer flow',
+  flow7q10: '7 day low flow with a 10 year return interval',
+}
+
+const metricYAxisLabels = {
+  mean_annual_flow: 'Mean annual flow (m<sup>3</sup>/s)',
+  MeanSummer: 'Mean summer flow (m<sup>3</sup>/s)',
+  WinterMean: 'Mean winter flow (m<sup>3</sup>/s)',
+  LCV: 'Variation',
+  LSkew: 'Skewness',
+  LKurt: 'Kurtosis',
+  AR1: 'Magnitude',
+  Amplitude: 'Correlation',
+  phase: 'Average day of year',
+  Spring2yr: 'Frequency',
+  Spring1pt5yr: 'Frequency',
+  Spring99: 'Number of days',
+  Spring95: 'Number of days',
+  Channelflow: 'Probability',
+  CtrFlowMass: 'Day of year',
+  Summer95: 'Number of days',
+  Summer20p: 'Number of days',
+  Highlow: 'Probability / mean',
+  flow7q10: '7 day low flow (m<sup>3</sup>/s)',
+}
+
+const metricDateRange = {
+  MeanSummer: 'Jun. 1 – Sep. 30',
+  WinterMean: 'Dec. 1 – Feb. 28',
+  Spring2yr: 'Feb. 1 – Aug. 1',
+  Spring1pt5yr: 'Feb. 1 – Aug. 1',
+  Spring99: 'Feb. 1 – Aug. 1',
+  Spring95: 'Feb. 1 – Aug. 1',
+  Summer95: 'Jun. 1 – Sep. 30',
+  Summer20p: 'Jun. 1 – Sep. 30',
 }
 
 const periodLabels = {
@@ -212,6 +241,22 @@ const renderPlot = () => {
     if (store.selected) {
       const { $Plotly } = useNuxtApp()
 
+      let metricLabel = metricLabels[metricSelection.value]
+      metricLabel = chartUtils.wordwrapString(metricLabel)
+      metricLabel = '<b>' + metricLabel + '</b>'
+
+      let areaString = store.selected
+      areaString = chartUtils.wordwrapString(areaString)
+
+      let chartTitle = metricLabel + '<br />' + areaString + '<br />'
+
+      if (metricDateRange.hasOwnProperty(metricSelection.value)) {
+        chartTitle +=
+          'Date Range: ' + metricDateRange[metricSelection.value] + ', '
+      }
+
+      chartTitle += 'Stream Order: ' + streamOrder
+
       // Create and populate each hydro stat stream order chart with traces.
       $Plotly.newPlot(
         'hydro-stats-chart-' + streamOrder,
@@ -220,16 +265,13 @@ const renderPlot = () => {
           autosize: true,
           height: 475,
           margin: {
+            t: chartUtils.topPadding(chartTitle),
             l: 75,
             r: 75,
           },
           title: {
-            text:
-              metricLabels[metricSelection.value] +
-              '<br />' +
-              store.selected +
-              '<br />Stream Order: ' +
-              streamOrder,
+            text: chartTitle,
+            y: 0.95,
           },
           xaxis: {
             tickvals: [0, 1, 2, 3],
@@ -239,7 +281,7 @@ const renderPlot = () => {
           yaxis: {
             automargin: true,
             title: {
-              text: metricLabels[metricSelection.value],
+              text: metricYAxisLabels[metricSelection.value],
               standoff: 15,
             },
           },
@@ -266,6 +308,14 @@ const renderPlot = () => {
         }
       )
 
+      chartTitle =
+        '<b>Hydrograph</b><br />' +
+        areaString +
+        '<br />Period: ' +
+        periodLabels[periodSelection.value] +
+        ', Stream Order: ' +
+        streamOrder
+
       // Create and populate each hydrology stream order chart with traces.
       $Plotly.newPlot(
         'hydrograph-chart-' + streamOrder,
@@ -274,17 +324,13 @@ const renderPlot = () => {
           autosize: true,
           height: 475,
           margin: {
+            t: chartUtils.topPadding(chartTitle),
             l: 75,
             r: 75,
           },
           title: {
-            text:
-              'Hydrograph<br />' +
-              store.selected +
-              '<br />Period: ' +
-              periodLabels[periodSelection.value] +
-              ', Stream Order: ' +
-              streamOrder,
+            text: chartTitle,
+            y: 0.95,
           },
           xaxis: {
             tickvals: [1, 91, 182, 274],

--- a/components/StreamTempCharts.vue
+++ b/components/StreamTempCharts.vue
@@ -36,6 +36,7 @@
 
 <script setup lang="ts">
 import { useStore } from '~/stores/store'
+import chartUtils from '~/utils/chartUtils'
 import { NSelect } from 'naive-ui'
 const store = useStore()
 
@@ -47,17 +48,17 @@ const modelLabels = {
 }
 
 const metricLabels = {
-  mean_ann: 'Mean Annual Temperature',
-  min_ann: 'Minimum Annual Temperature',
-  max_ann: 'Maximum Annual Temperature',
-  gsdd: 'Growing Season Degree Days',
-  mean_apr: 'Mean April Temperature',
-  mean_may: 'Mean May Temperature',
-  mean_jun: 'Mean June Temperature',
-  mean_jul: 'Mean July Temperature',
-  mean_aug: 'Mean August Temperature',
-  mean_sep: 'Mean September Temperature',
-  mean_oct: 'Mean October Temperature',
+  mean_ann: 'Mean annual temperature',
+  min_ann: 'Minimum annual temperature',
+  max_ann: 'Maximum annual temperature',
+  gsdd: 'Growing season degree days',
+  mean_apr: 'Mean April temperature',
+  mean_may: 'Mean May temperature',
+  mean_jun: 'Mean June temperature',
+  mean_jul: 'Mean July temperature',
+  mean_aug: 'Mean August temperature',
+  mean_sep: 'Mean September temperature',
+  mean_oct: 'Mean October temperature',
 }
 
 const unitLabels = {
@@ -152,6 +153,18 @@ const renderPlot = () => {
     if (store.selected) {
       const { $Plotly } = useNuxtApp()
 
+      let areaString = store.selected
+      areaString = chartUtils.wordwrapString(areaString)
+
+      let chartTitle =
+        '<b>' +
+        metricLabels[metricSelection.value] +
+        '</b>' +
+        '<br />' +
+        areaString +
+        '<br />Stream Order: ' +
+        streamOrder
+
       // Create and populate chart with traces.
       $Plotly.newPlot(
         'stream-temp-chart-' + streamOrder,
@@ -160,16 +173,13 @@ const renderPlot = () => {
           autosize: true,
           height: 475,
           margin: {
+            t: chartUtils.topPadding(chartTitle),
             l: 75,
             r: 75,
           },
           title: {
-            text:
-              metricLabels[metricSelection.value] +
-              '<br />' +
-              store.selected +
-              '<br />Stream Order: ' +
-              streamOrder,
+            text: chartTitle,
+            y: 0.95,
           },
           xaxis: {
             tickvals: [0, 1, 2, 3],

--- a/utils/chartUtils.ts
+++ b/utils/chartUtils.ts
@@ -1,0 +1,23 @@
+const wordwrapString = str => {
+  if (str.length > 50) {
+    let start = Math.floor(str.length / 2)
+    for (let i = start; i < str.length; i++) {
+      if (str[i] == ' ') {
+        let above = str.substr(0, i)
+        let below = str.substr(i + 1)
+        return above + '<br />' + below
+      }
+    }
+  }
+  return str
+}
+
+// Adjust top padding depending on number of line breaks in title.
+const topPadding = str => {
+  return 100 + (str.split('<br />').length - 3) * 20
+}
+
+export default {
+  wordwrapString,
+  topPadding,
+}


### PR DESCRIPTION
Closes #29.
Closes #47.

This PR fixes up the names of the selectable metrics for the Hydrology charts, and adds a lot of small text and formatting improvements to all Plotly charts in general:

- It adds human-readable names for the selectable metrics for the hydrology stats charts (the charts in the left column under the "Hydrology" section). These metrics can have very long names (e.g., "Number of days summer flows were less than 20% of the mean annual flow"), but IMO we need to keep them long to be clear about what they are showing. This may be something we iterate on later, though.
- Because some AOIs have long names, and because the metrics mentioned above can have long names, I've added word-wrapping to chart titles to ensure that the titles never get cropped off the sides of the chart, regardless of browser size.
- I've bolded the name of the metric in all chart titles to help differentiate the metric vs. AOI name vs. other stuff in the chart titles.
- I've made some adjustments to chart margins to add more breathing room for the chart titles.
- Chart titles have been modified across the board to have the same style of title capitalization.

To test, load the app and select an AOI with a very long name. Scroll down to the "Hydrology" section of the report page and observe that the selectable metrics in the dropdown menu have more descriptive names than before. Select a metric with a long name and verify that the chart titles word-wrap appropriately and look generally nice.