### PR TITLE
Encode AOI name in GET parameter when fetching polygon from GeoServer

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-GEOSERVER_URL=https://gs.mapventure.org/geoserver/fish_and_fire/ows?service=WFS&version=1.0.0&request=GetFeature&typeName=fish_and_fire%3AAOI_v2&outputFormat=application%2Fjson
+GEOSERVER_URL=https://gs.mapventure.org/geoserver/fish_and_fire/ows?service=WFS&version=1.0.0&request=GetFeature&typeName=fish_and_fire%3AAOIs&outputFormat=application%2Fjson

--- a/components/Map.vue
+++ b/components/Map.vue
@@ -105,7 +105,7 @@ onMounted(() => {
     transparent: true,
     format: 'image/png',
     version: '1.3.0',
-    layers: ['fish_and_fire:AOI_v2_shadowmask'],
+    layers: ['fish_and_fire:AOIs_shadowmask'],
   })
 
   if (map == undefined) {

--- a/stores/store.ts
+++ b/stores/store.ts
@@ -88,7 +88,7 @@ export const useStore = defineStore('store', () => {
       let geoserverUrl =
         runtimeConfig.public.geoserverUrl +
         "&cql_filter=AOI_Name_='" +
-        selected.value +
+        encodeURIComponent(selected.value) +
         "'"
       let response = await $fetch(geoserverUrl)
       if (response != undefined) {


### PR DESCRIPTION
Closes #49.

This PR encodes the name of the selected AOI before sending it off as a GET parameter to GeoServer. This fixes the polygon fetch operation if an AOI has an ampersand in its name.

To test, load the app and select an AOI with an ampersand in its name. The polygon for the AOI should load successfully on the map on the report page (above the charts).