### PR TITLE
Fix typos in AOI names

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-GEOSERVER_URL=https://gs.mapventure.org/geoserver/fish_and_fire/ows?service=WFS&version=1.0.0&request=GetFeature&typeName=fish_and_fire%3AAOI_v2&outputFormat=application%2Fjson
+GEOSERVER_URL=https://gs.mapventure.org/geoserver/fish_and_fire/ows?service=WFS&version=1.0.0&request=GetFeature&typeName=fish_and_fire%3AAOIs&outputFormat=application%2Fjson

--- a/components/Map.vue
+++ b/components/Map.vue
@@ -105,7 +105,7 @@ onMounted(() => {
     transparent: true,
     format: 'image/png',
     version: '1.3.0',
-    layers: ['fish_and_fire:AOI_v2_shadowmask'],
+    layers: ['fish_and_fire:AOIs_shadowmask'],
   })
 
   if (map == undefined) {

--- a/scripts/csv2json.py
+++ b/scripts/csv2json.py
@@ -53,6 +53,12 @@ column_settings = {
     },
 }
 
+aoi_name_fixes = {
+    "Fire Managment Zone DAS": "Fire Management Zone DAS",
+    "Fire Managment Zone FAS": "Fire Management Zone FAS",
+    "Fire Managment Zone MID": "Fire Management Zone MID",
+}
+
 parser = argparse.ArgumentParser(description="Convert CSV file to JSON.")
 parser.add_argument("input_file", type=str, help="input CSV file")
 parser.add_argument("output_file", type=str, help="output JSON file")
@@ -124,7 +130,13 @@ for row in df.values.tolist():
         if row[index] == -9999:
             include_row = False
             break
-        value_dict = value_dict[row[index]]
+
+        # If the dictionary/JSON key is an AOI name, fix it if necessary.
+        key = row[index]
+        if group_headers[index] == "AOI" and key in aoi_name_fixes.keys():
+            key = aoi_name_fixes[key]
+
+        value_dict = value_dict[key]
 
     # Add leaves (values) to this branch of the nested dict.
     if include_row:

--- a/stores/store.ts
+++ b/stores/store.ts
@@ -34,7 +34,8 @@ export const useStore = defineStore('store', () => {
       }
 
       const runtimeConfig = useRuntimeConfig()
-      let geoserverUrl = runtimeConfig.public.geoserverUrl
+      let geoserverUrl =
+        runtimeConfig.public.geoserverUrl + '&PropertyName=(AOI_Name_,Category)'
       let response = await $fetch(geoserverUrl)
       if (response != undefined) {
         response.features.forEach(area => {


### PR DESCRIPTION
Closes #51.

This PR does a few things:

- Updates the GeoServer URL to reference a new AOI shapefile simply named `AOIs` instead of using a version number like before (`AOI_v2`). This is the same shapefile as before, but with a few AOI typo fixes included. I decided it'd be best to drop the version number from the GeoServer layer name to help future proof the code.
- Updates the shadow mask layer in GeoServer to use a similar version-less naming scheme.
- Adds a couple lines to the Python preprocessing script to make the same AOI typo fixes, so the AOI names from GeoServer match the AOI names in the JSON data files.
- Adds `'&PropertyName=(AOI_Name_,Category)'` back to the AOI name/category fetch operation. These additional GET parameters went missing somewhere along the way. This just adds them back to make the HTTP request much faster.

To test, follow the "Convert CSV files to JSON" procedure from the README, then run the app and make sure the Fire Management Zone typo fixes are in place and charts load successfully when you choose a Fire Management Zone.