### PR TITLE
Add an additional "Go Back" button near the top of the results view

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -17,6 +17,7 @@
       </div>
     </div>
     <div v-show="store.selectedArea" class="section">
+      <BackButton class="mb-6" />
       <FishGrowthCharts
         v-if="store.selectedArea && store.hasArea('fishGrowth')"
       />


### PR DESCRIPTION
Closes #53.

This PR simply places another back button near the top of the results view, right under the map.

To test, select an AOI and and confirm that the back button near the top of the page works as expected. It uses the same component as the other back button, so it should!