### PR TITLE
Update ALFRESCO description link to ALFRESCO Guide PDF

### DIFF
--- a/components/FishGrowthCharts.vue
+++ b/components/FishGrowthCharts.vue
@@ -23,7 +23,7 @@
       salmon growth were simulated on an 8-day timestep. Wildfires were
       simulated across the study area based on probabilistic flammability
       metrics (<a
-        href="https://uaf-snap.org/wp-content/uploads/2020/06/ALFRESCO_overview.pdf"
+        href="https://github.com/ua-snap/alfresco/blob/main/docs/ALFRESCO_Guide.pdf"
         >described here</a
       >), influenced by vegetation type, climate, and fire management option.
     </p>


### PR DESCRIPTION
Closes #104.

This PR simply updates the ALFRESCO description link under the Fish Growth section of the webapp to the authoritative version of the ALFRESCO Guide PDF.

To test, click the "described here" link in the following text in the Fish Growth section:

> Wildfires were simulated across the study area based on probabilistic flammability metrics (**described here**)...

This will take you to GitHub's PDF viewer interface. We have the option to either view the PDF this way, or to trigger a download of the PDF. Unfortunately GitHub does not appear to support viewing the PDF directly through your web browser's PDF reader, but I think using GitHub's built-in PDF viewer is sufficient.