### PR TITLE
Use text labels instead of numbers for hydro chart stream orders

### DIFF
--- a/components/HydroCharts.vue
+++ b/components/HydroCharts.vue
@@ -13,6 +13,7 @@
       the selected management units. These calculations were based on the annual
       water year, which runs from October 1 to September 30.
     </p>
+    <p>In the charts below, MAF stands for mean annual flow.</p>
   </section>
   <div class="columns is-desktop">
     <div class="column is-half-desktop">
@@ -123,6 +124,13 @@ const metricDateRange = {
 const periodLabels = {
   '1': '2038-2047',
   '2': '2068-2077',
+}
+
+const streamStrings = {
+  '1': 'Headwater Streams (MAF ≤ 1m<sup>3</sup>/s)',
+  '2': 'Small Tributaries (1 < MAF ≤ 5m<sup>3</sup>/s)',
+  '3': 'Large Tributaries (5 < MAF ≤ 25m<sup>3</sup>/s)',
+  '4': 'Main Stem Rivers (MAF > 25m<sup>3</sup>/s)',
 }
 
 const metricOptions = []
@@ -282,10 +290,10 @@ const renderPlot = () => {
 
     if (metricDateRange.hasOwnProperty(metricSelection.value)) {
       chartTitle +=
-        'Date Range: ' + metricDateRange[metricSelection.value] + ', '
+        'Date Range: ' + metricDateRange[metricSelection.value] + '<br />'
     }
 
-    chartTitle += 'Stream Order: ' + streamOrder
+    chartTitle += streamStrings[streamOrder]
 
     // Create and populate each hydro stat stream order chart with traces.
     $Plotly.newPlot(
@@ -343,8 +351,8 @@ const renderPlot = () => {
       areaString +
       '<br />Period: ' +
       periodLabels[periodSelection.value] +
-      ', Stream Order: ' +
-      streamOrder
+      '<br />' +
+      streamStrings[streamOrder]
 
     // Create and populate each hydrology stream order chart with traces.
     $Plotly.newPlot(


### PR DESCRIPTION
Closes #74.

This PR replaces the numeric stream orders in the chart titles under the "Hydrology" section with text labels. It does not affect the chart titles of the other sections, however, which still use numeric stream orders.

To test, do a fresh run of the "Convert CSV files to JSON" instructions in the README to grab the latest set of CSV files and process them into a new set of JSON files. This is necessary because new `Hydrology_Stats_by_AOI.csv` and `Hydrograph_Data_by_AOI.csv` files have been provided that recategorize the data into just four stream orders, corresponding to the four stream order text labels that were provided.

After generating the new JSON files, load the app, choose an AOI, and verify that all of the charts under the "Hydrology" section are using the new text labels in their titles.