### PR TITLE
Use "riparian fire index" instead of "riparian fire impact" throughout app

### DIFF
--- a/components/FireImpactCharts.vue
+++ b/components/FireImpactCharts.vue
@@ -1,6 +1,6 @@
 <template>
   <section class="section content is-size-5">
-    <h1 class="title">Riparian Fire Impact</h1>
+    <h1 class="title">Riparian Fire Index</h1>
     <p>
       This section shows projections for the mean riparian fire index, compared
       with a historical range (2002&ndash;2018). Results are presented for low,
@@ -30,7 +30,7 @@
   <div class="columns">
     <div class="column is-half">
       <NRadioGroup v-model:value="fmoSelection" name="fmo-group">
-        <FmoRadioLabel/>
+        <FmoRadioLabel />
         <NSpace>
           <NRadio
             v-for="fmoOption in fmoOptions"
@@ -238,7 +238,7 @@ const renderPlot = () => {
       },
       title: {
         text:
-          '<b>Riparian fire impact</b><br />' +
+          '<b>Riparian fire index</b><br />' +
           store.aoiName +
           '<br />' +
           fmoLabels[fmoSelection.value] +
@@ -253,7 +253,7 @@ const renderPlot = () => {
       yaxis: {
         automargin: true,
         title: {
-          text: 'Riparian Fire Impact',
+          text: 'Riparian Fire Index',
           standoff: 15,
         },
       },
@@ -273,7 +273,7 @@ const renderPlot = () => {
         'resetScale2d',
       ],
       toImageButtonOptions: {
-        filename: 'riparian_fire_impact',
+        filename: 'riparian_fire_index',
       },
     }
   )

--- a/pages/fmo.vue
+++ b/pages/fmo.vue
@@ -4,7 +4,7 @@
       <h1 class="title">Fire Management Options (FMO)</h1>
       <p>
         Flammability simulations from the ALFRESCO model were used as inputs for
-        the fish growth and riparian fire impact projections displayed in this
+        the fish growth and riparian fire index projections displayed in this
         tool. These ALFRESCO simulations were run using three different fire
         suppression scenarios, incorporating data from the
         <a href="https://fire.ak.blm.gov/"
@@ -35,7 +35,7 @@
         <a href="https://github.com/ua-snap/alfresco">ALFRESCO model</a> and
         <a href="https://github.com/ua-snap/alfresco_fmo">ALFRESCO FMO inputs</a
         >. The ALFRESCO data used as inputs for fish growth and riparian fire
-        impacts are
+        index are
         <a
           href="https://catalog.snap.uaf.edu/geonetwork/srv/eng/catalog.search#/metadata/3be7e974-df96-4eef-bb41-ee16f625124f"
           >available for download here</a

--- a/pages/report.vue
+++ b/pages/report.vue
@@ -51,7 +51,7 @@
             the area of interest
           </li>
           <li>
-            <strong>Riparian fire impact charts</strong> by fire management
+            <strong>Riparian fire index charts</strong> by fire management
             option and by fish species
           </li>
           <li>


### PR DESCRIPTION
Closes #63.

This PR replaces the old "riparian fire impact" phrase to "riparian fire index" in all the places where it hadn't been updated yet (section title, chart titles and axes, etc.)

To test, confirm that there is no trace of "riparian fire impact" on the public facing part of the website. The old naming scheme is still used for the component name, data files, and keys because it didn't seem worth the effort to update them.