### PR TITLE
Remove Channelflow hydrology statistic from dropdown, charts, and JSON data files

### DIFF
--- a/components/HydroCharts.vue
+++ b/components/HydroCharts.vue
@@ -77,7 +77,6 @@ const metricLabels = {
   Spring1pt5yr: 'Frequency of spring 1.5 year high flows',
   Spring99: 'Number of days spring flows were in the top 1% of annual flows',
   Spring95: 'Number of days spring flows were in the top 5% of annual flows',
-  Channelflow: 'Probability 1.5 year flow event would occur during a year',
   CtrFlowMass: 'Center of timing of the mass of flow for an annual water year',
   Summer95: 'Number of days summer flows were in the top 5% of annual flows',
   Summer20p:
@@ -101,7 +100,6 @@ const metricYAxisLabels = {
   Spring1pt5yr: 'Frequency',
   Spring99: 'Number of days',
   Spring95: 'Number of days',
-  Channelflow: 'Probability',
   CtrFlowMass: 'Day of year',
   Summer95: 'Number of days',
   Summer20p: 'Number of days',

--- a/scripts/csv2json.py
+++ b/scripts/csv2json.py
@@ -66,6 +66,7 @@ column_settings = {
         "omit": [
             "RCA",
             "ReachID",
+            "Channelflow",
         ],
     },
     "Riparian_Fire_Impact_by_AOI.csv": {


### PR DESCRIPTION
Closes #106.

This PR removes the Channelflow (aka, "Probability 1.5 year flow event would occur during a year") statistic from the Hydrology Statistics dropdown menu / chart options. The Channelflow field is now also omitted from the JSON files during preprocessing since it is no longer used.

To test, verify that the "Probability 1.5 year flow event would occur during a year" option is no longer present in the Hydrology Statistics dropdown menu on the AOI report page.