### PR TITLE
Use consistent y-axis range for fish growth and stream temperature charts

### DIFF
--- a/components/HydroCharts.vue
+++ b/components/HydroCharts.vue
@@ -159,7 +159,10 @@ const renderPlot = () => {
 
   // Add separate hydrology stat and hydrograph charts for each stream order.
   streamOrders.value.forEach(streamOrder => {
-    if (store.areaData['hydroStats'][streamOrder]['ccsm'] == undefined) {
+    if (
+      store.areaData['hydroStats'][streamOrder]['ccsm'] == undefined ||
+      store.areaData['hydroStats'][streamOrder]['ccsm']['0'] == undefined
+    ) {
       return
     }
 

--- a/components/StreamTempCharts.vue
+++ b/components/StreamTempCharts.vue
@@ -109,6 +109,43 @@ const streamOrders = computed(() => {
   return Object.keys(store.areaData['streamTemp'])
 })
 
+const yAxisRange = computed(() => {
+  // Collect all values in this array to be used to determine shared min/max
+  // values for y-axis range across all fish growth charts.
+  let allValues = []
+
+  streamOrders.value.forEach(streamOrder => {
+    let historicalValue =
+      store.areaData['streamTemp'][streamOrder]['ccsm']['0'][
+        metricSelection.value
+      ]
+    allValues.push(historicalValue)
+
+    let models = Object.keys(store.areaData['streamTemp'][streamOrder])
+    models.forEach(model => {
+      let periods = Object.keys(
+        store.areaData['streamTemp'][streamOrder][model]
+      )
+      for (let period = 1; period < periods.length; period++) {
+        let projectedValue =
+          store.areaData['streamTemp'][streamOrder][model][period][
+            metricSelection.value
+          ]
+        allValues.push(projectedValue)
+      }
+    })
+  })
+
+  let minValue = Math.min.apply(Math, allValues)
+  let maxValue = Math.max.apply(Math, allValues)
+
+  // Add some padding above/below min/max so plot markers don't get cropped.
+  minValue -= minValue > 0 ? minValue * 0.03 : maxValue * 0.03
+  maxValue += maxValue * 0.03
+
+  return [minValue, maxValue]
+})
+
 const renderPlot = () => {
   const symbols = {
     era: 'circle',
@@ -123,7 +160,10 @@ const renderPlot = () => {
 
   // Add a separate chart for each available stream order.
   streamOrders.value.forEach(streamOrder => {
-    if (store.areaData['streamTemp'][streamOrder]['ccsm'] == undefined) {
+    if (
+      store.areaData['streamTemp'][streamOrder]['ccsm'] == undefined ||
+      store.areaData['streamTemp'][streamOrder]['ccsm']['0'] == undefined
+    ) {
       return
     }
 
@@ -216,6 +256,7 @@ const renderPlot = () => {
             text: yAxisLabels[metricSelection.value],
             standoff: 15,
           },
+          range: yAxisRange.value,
         },
       },
       {

--- a/scripts/csv2json.py
+++ b/scripts/csv2json.py
@@ -175,7 +175,6 @@ for run in runs:
         os.makedirs(run["output_dir"])
 
     for key in data_dict.keys():
-        data_dict[key]["aoi"] = key
         # Generate 6-digit hash for each AOI to be used in permalinks.
         sha_1 = hashlib.sha1()
         sha_1.update(key.encode("utf-8"))


### PR DESCRIPTION
Closes #69.

This PR modifies the Fish Growth and Stream Temperature charts to use consistent y-axis ranges where appropriate and feasible. To be more precise:

**Fish Growth charts:** For each AOI, the y-axis range will adapt to the min/max values across all stream orders and FMOs. So, when looking at all of the charts, and when toggling between the different FMO options, all of the charts will have the same y-axis scale. This makes it much easier to compare values between the charts at a glance.

**Stream Temperature charts:** For each AOI, the y-axis range will adapt to the min/max values across all stream orders for a selected stream temperature statistic. The y-axis range will change when choosing different options from the stream temperature statistic dropdown, however, but this is intentional.

The rest of the charts on an AOI's report page have not been changed because there either wasn't as much benefit to doing so (riparian fire impact charts) or it seemed like an apples-to-oranges comparison (hydro stats and hydrographs).

I've also added a couple more error guards to the code, and removed an unused field from the JSON data files that was causing problems.

To test, run through the "Convert CSV files to JSON" instructions in the README again to generate new JSON data files. Then run the app, load the report page for a few different AOI's, and confirm that the chart y-axes behave as described above for Fish Growth and Stream Temperature charts.