### PR TITLE
Add Umami analytics

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -17,6 +17,20 @@ export default defineNuxtConfig({
       { name: 'viewport', content: 'width=device-width, initial-scale=1' },
     ],
   },
+  app: {
+    head: {
+      script: [
+        {
+          src: 'https://umami.snap.uaf.edu/umami.js',
+          'data-website-id': '0d96da3f-f9c7-4f69-946d-848d38c0b5d3',
+          'data-do-not-track': 'true',
+          'data-domains': 'snap.uaf.edu',
+          async: 'true',
+          defer: 'true',
+        },
+      ],
+    },
+  },
   build: {
     transpile:
       process.env.NODE_ENV === 'production'


### PR DESCRIPTION
Closes #25.

This PR adds Umami analytics to the web app. I tried to use the nuxt-umami module but wasn't able to get it working in Nuxt 3 using the official documentation, strangely, so I've added the Umami config to a script tag in the Nuxt config.

To test, coment out the `'data-domains': 'snap.uaf.edu'` line in `nuxt.config.ts` and confirm that web app traffic shows up in the "Fish & Fire" website property on our Umami server.