### PR TITLE
Increase resolution of exported charts

### DIFF
--- a/components/FireImpactCharts.vue
+++ b/components/FireImpactCharts.vue
@@ -30,7 +30,7 @@
   <div class="columns">
     <div class="column is-half">
       <NRadioGroup v-model:value="fmoSelection" name="fmo-group">
-        <FmoRadioLabel/>
+        <FmoRadioLabel />
         <NSpace>
           <NRadio
             v-for="fmoOption in fmoOptions"
@@ -274,6 +274,7 @@ const renderPlot = () => {
       ],
       toImageButtonOptions: {
         filename: 'riparian_fire_impact',
+        scale: 2,
       },
     }
   )

--- a/components/FishGrowthCharts.vue
+++ b/components/FishGrowthCharts.vue
@@ -231,6 +231,7 @@ const renderPlot = () => {
         ],
         toImageButtonOptions: {
           filename: 'fish_growth',
+          scale: 2,
         },
       }
     )

--- a/components/HydroCharts.vue
+++ b/components/HydroCharts.vue
@@ -334,6 +334,7 @@ const renderPlot = () => {
           filename: metricLabels[metricSelection.value]
             .toLowerCase()
             .replace(/ /g, '_'),
+          scale: 2,
         },
       }
     )
@@ -392,6 +393,7 @@ const renderPlot = () => {
         ],
         toImageButtonOptions: {
           filename: 'hydrograph',
+          scale: 2,
         },
       }
     )

--- a/components/StreamTempCharts.vue
+++ b/components/StreamTempCharts.vue
@@ -236,6 +236,7 @@ const renderPlot = () => {
           filename: metricLabels[metricSelection.value]
             .toLowerCase()
             .replace(/ /g, '_'),
+          scale: 2,
         },
       }
     )


### PR DESCRIPTION
Closes #68.

This PR doubles the resolution of all charts when they are exported as PNGs.

To test, click the camera icon in the upper right corner of each of these five different types of charts:

- Fish growth
- Riparian fire impact
- Hydrology statistics (left column under Hydrology)
- Hydrograph (right column under Hydrology)
- Stream temperature

They should all export much larger than before.