### PR TITLE
Include Leaflet images in static site generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "scripts": {
     "dev": "nuxi dev",
-    "build": "nuxi build"
+    "build": "cp node_modules/leaflet/dist/images/* public/ && nuxi build"
   },
   "devDependencies": {
     "eslint": "^8.39.0",

--- a/public/README.md
+++ b/public/README.md
@@ -1,0 +1,1 @@
+Leaflet images will be copied into this directory during static site generation.


### PR DESCRIPTION
Closes #95.

This PR solves the issue of Leaflet's image files missing from the static site build. It does so by simply copying all required Leaflet images into the `public` subdirectory as part of the `npm run build` script.

To test, run `npm run build`. The following two files should appear in the `.output/public` subdirectory:

- layers-2x.png
- marker-shadow.png