### PR TITLE
Remove blank Channelflow option from hydrology statistics dropdown

### DIFF
--- a/components/HydroCharts.vue
+++ b/components/HydroCharts.vue
@@ -167,10 +167,6 @@ const metricOptions = [
         value: 'Spring95',
       },
       {
-        label: metricLabels['Channelflow'],
-        value: 'Channelflow',
-      },
-      {
         label: metricLabels['CtrFlowMass'],
         value: 'CtrFlowMass',
       },


### PR DESCRIPTION
Closes #126.

This PR removes the blank option from the Hydrology Statistics dropdown menu where the Channelflow statistic used to be. 

To test, load the report for an AOI that has the "Hydrology" section present. For example:

http://localhost:3000/report/249c37

Observe that there is no longer a blank option between these two hydrology statistics:

- Number of days spring flows were in the top 5% of annual flows
- Center of timing of the mass of flow for an annual water year