### PR TITLE
Add explanation of the types of places that are selectable

### DIFF
--- a/components/IntersectingAreas.vue
+++ b/components/IntersectingAreas.vue
@@ -13,6 +13,18 @@
           Click to choose from the 300+ place names in the box above
         </li>
       </ul>
+      <p class="is-size-5 mb-5">Types of places include:</p>
+      <ul class="list is-size-5">
+        <li class="list-item">
+          Alaska Department of Fish and Game (ADF&G) Game Management Units
+        </li>
+        <li class="list-item">
+          Alaska Fire Service (AFS) Fire Management Units
+        </li>
+        <li class="list-item">Park and Conservation Units</li>
+        <li class="list-item">Department of Defense (DOD) Lands</li>
+        <li class="list-item">Hydrologic Units Codes (HUCs)</li>
+      </ul>
     </div>
     <h5 class="title is-5" v-if="store.matchedAreaNames.length > 0">
       Found {{ store.matchedAreaNames.length }} matching areas for


### PR DESCRIPTION
Closes #96.

This PR simply adds a text blurb to the front page under the AOI search instructions to indicate what types of places are selectable.