### PR TITLE
Reorder sections of report page, TOC links, and dynamic text blurb

### DIFF
--- a/components/FishGrowthCharts.vue
+++ b/components/FishGrowthCharts.vue
@@ -111,6 +111,56 @@ const streamOrders = computed(() => {
   return Object.keys(store.areaData['fishGrowth'][fmoSelection.value])
 })
 
+const yAxisRange = computed(() => {
+  // Collect all values in this array to be used to determine shared min/max
+  // values for y-axis range across all fish growth charts.
+  let allValues = []
+
+  let fmos = fmoOptions.map(fmoOption => {
+    return fmoOption.value
+  })
+
+  streamOrders.value.forEach(streamOrder => {
+    if (
+      store.areaData['fishGrowth']['hist'][streamOrder]['ccsm'] == undefined ||
+      store.areaData['fishGrowth']['hist'][streamOrder]['ccsm']['0'] ==
+        undefined
+    ) {
+      return
+    }
+    let historicalValue =
+      store.areaData['fishGrowth']['hist'][streamOrder]['ccsm']['0'][
+        'FishWeight'
+      ]
+    allValues.push(historicalValue)
+
+    fmos.forEach(fmo => {
+      let models = Object.keys(store.areaData['fishGrowth'][fmo][streamOrder])
+      models.forEach(model => {
+        let periods = Object.keys(
+          store.areaData['fishGrowth'][fmo][streamOrder][model]
+        )
+        for (let period = 1; period <= periods.length; period++) {
+          let projectedValue =
+            store.areaData['fishGrowth'][fmo][streamOrder][model][period][
+              'FishWeight'
+            ]
+          allValues.push(projectedValue)
+        }
+      })
+    })
+  })
+
+  let minValue = Math.min.apply(Math, allValues)
+  let maxValue = Math.max.apply(Math, allValues)
+
+  // Add some padding above/below min/max so plot markers don't get cropped.
+  minValue -= minValue > 0 ? minValue * 0.03 : maxValue * 0.03
+  maxValue += maxValue * 0.03
+
+  return [minValue, maxValue]
+})
+
 const renderPlot = () => {
   const symbols = {
     era: 'circle',
@@ -221,6 +271,7 @@ const renderPlot = () => {
             text: 'Fish Weight (g)',
             standoff: 15,
           },
+          range: yAxisRange.value,
         },
       },
       {

--- a/components/HydroCharts.vue
+++ b/components/HydroCharts.vue
@@ -264,7 +264,10 @@ const renderPlot = () => {
 
   // Add separate hydrology stat and hydrograph charts for each stream order.
   streamOrders.value.forEach(streamOrder => {
-    if (store.areaData['hydroStats'][streamOrder]['ccsm'] == undefined) {
+    if (
+      store.areaData['hydroStats'][streamOrder]['ccsm'] == undefined ||
+      store.areaData['hydroStats'][streamOrder]['ccsm']['0'] == undefined
+    ) {
       return
     }
 

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -18,6 +18,20 @@ export default defineNuxtConfig({
     ],
     link: [{ rel: 'manifest', href: '/site.webmanifest' }],
   },
+  app: {
+    head: {
+      script: [
+        {
+          src: 'https://umami.snap.uaf.edu/umami.js',
+          'data-website-id': '0d96da3f-f9c7-4f69-946d-848d38c0b5d3',
+          'data-do-not-track': 'true',
+          'data-domains': 'snap.uaf.edu',
+          async: 'true',
+          defer: 'true',
+        },
+      ],
+    },
+  },
   build: {
     transpile:
       process.env.NODE_ENV === 'production'

--- a/pages/report.vue
+++ b/pages/report.vue
@@ -54,10 +54,6 @@
         </p>
 
         <ul>
-          <li v-if="store.areaData['fishGrowth']">
-            <a href="#fish-growth">Fish growth charts</a> for each stream order
-            present in the area of interest
-          </li>
           <li v-if="store.areaData['fireImpact']">
             <a href="#fire-impact">Riparian fire index charts</a> by fire
             management option and by fish species
@@ -72,13 +68,14 @@
             <a href="#stream-temp">Stream temperature charts</a> for each stream
             order present in the area of interest
           </li>
+          <li v-if="store.areaData['fishGrowth']">
+            <a href="#fish-growth">Fish growth charts</a> for each stream order
+            present in the area of interest
+          </li>
         </ul>
       </div>
     </section>
     <div class="charts">
-      <div id="fish-growth" v-if="store.areaData['fishGrowth']">
-        <FishGrowthCharts />
-      </div>
       <div id="fire-impact" v-if="store.areaData['fireImpact']">
         <FireImpactCharts />
       </div>
@@ -90,6 +87,9 @@
       </div>
       <div id="stream-temp" v-if="store.areaData['streamTemp']">
         <StreamTempCharts />
+      </div>
+      <div id="fish-growth" v-if="store.areaData['fishGrowth']">
+        <FishGrowthCharts />
       </div>
       <BackButton />
     </div>
@@ -117,17 +117,17 @@ store.fetchResultData()
 
 const availableDataString = computed(() => {
   let availableData = []
-  if (store.areaData['fishGrowth']) {
-    availableData.push('fish growth')
-  }
   if (store.areaData['fireImpact']) {
     availableData.push('riparian fire effects')
+  }
+  if (store.areaData['hydroStats'] && store.areaData['hydrograph']) {
+    availableData.push('hydrology')
   }
   if (store.areaData['streamTemp']) {
     availableData.push('stream temperature')
   }
-  if (store.areaData['hydroStats'] && store.areaData['hydrograph']) {
-    availableData.push('hydrology')
+  if (store.areaData['fishGrowth']) {
+    availableData.push('fish growth')
   }
   if (availableData.length > 2) {
     let allButLast = availableData.slice(0, availableData.length - 1).join(', ')

--- a/scripts/csv2json.py
+++ b/scripts/csv2json.py
@@ -176,7 +176,6 @@ for run in runs:
         os.makedirs(run["output_dir"])
 
     for key in data_dict.keys():
-        data_dict[key]["aoi"] = key
         # Generate 6-digit hash for each AOI to be used in permalinks.
         sha_1 = hashlib.sha1()
         sha_1.update(key.encode("utf-8"))


### PR DESCRIPTION
Closes #102 (again).

This PR reorders the sections of the AOI report page to be:

- Riparian Fire
- Hydrology
- Stream Temperature
- Fish Growth

It also reorders the short dynamic text blurb and TOC links in the AOI report page introduction section to match.

This was already done once before, but I think the PR merge conflict resolutions reverted back to the previous order.