### PR TITLE
Make many small text fixes for clarity and consistency

### DIFF
--- a/components/BackButton.vue
+++ b/components/BackButton.vue
@@ -1,6 +1,6 @@
 <template>
   <NButton type="info" @click="router.push({ name: 'index' })"
-    >Go back, pick another place&hellip;</NButton
+    >Go back, pick another place</NButton
   >
 </template>
 

--- a/components/FireImpactCharts.vue
+++ b/components/FireImpactCharts.vue
@@ -3,10 +3,10 @@
     <h1 class="title">Riparian Fire Index</h1>
     <p>
       This section shows projections for the mean riparian fire index, compared
-      with a historical dataset (ERA). Results are presented for low, neutral,
-      and high intensity wildfire scenarios for two specific climate models
-      (NCAR-CCSM4 and GFDL-CM3). The fire scenarios are a function of fire size,
-      intensity, and fire weather.
+      with a historical dataset (ERA5 Reanalysis). Results are presented for
+      low, neutral, and high intensity wildfire scenarios for two specific
+      climate models (NCAR-CCSM4 and GFDL-CM3). The fire scenarios are a
+      function of fire size, intensity, and fire weather.
     </p>
 
     <p>
@@ -18,8 +18,8 @@
 
     <p>
       Results are presented for the base riparian fire index (species = none),
-      as a vulnerability index for two fish species, juvenile Chinook Salmon,
-      and Arctic Grayling, and for three
+      as a vulnerability index for two fish species, juvenile Chinook salmon,
+      and Arctic grayling, and for three
       <a @click="router.push({ name: 'fmo' })">fire management options</a>. The
       vulnerability index is a function of the mean riparian fire index, the
       total length of high suitability fish habitat relative to total stream
@@ -83,8 +83,8 @@ const fmoLabels = {
 
 const speciesLabels = {
   NONE: 'None',
-  CHK: 'Chinook',
-  GRA: 'Grayling',
+  CHK: 'Chinook salmon',
+  GRA: 'Arctic grayling',
 }
 
 const modelLabels = {
@@ -159,7 +159,7 @@ const renderPlot = () => {
     let trace = {
       type: 'scatter',
       mode: 'markers',
-      name: 'ERA (' + prefix + ' Intensity)',
+      name: 'ERA5 (' + prefix + ' Intensity)',
       x: [1 + xOffset, 2 + xOffset, 3 + xOffset],
       y: [fmoData['ccsm'][0][meanKey]],
       marker: {

--- a/components/FishGrowthCharts.vue
+++ b/components/FishGrowthCharts.vue
@@ -6,14 +6,14 @@
       under three
       <a @click="router.push({ name: 'fmo' })">fire management options</a>.
       Future projections are presented for two specific climate models
-      (NCAR-CCSM4 and GFDL-CM3), compared with a historical dataset (ERA).
-      Growth potential indicates how large a well-fed juvenile Chinook salmon
-      could potentially grow by the end of its first summer, in terms of body
-      wet weight (g). Simulations account for changes in stream temperature
-      influenced by climate and wildfire, assuming that fish feeding rates and
-      food quality remain similar to their current values in the future. Only
-      stream reaches containing adequate habitat for juvenile Chinook salmon are
-      included (based on a model of underlying geomorphology,
+      (NCAR-CCSM4 and GFDL-CM3), compared with a historical dataset (ERA5
+      Reanalysis). Growth potential indicates how large a well-fed juvenile
+      Chinook salmon could potentially grow by the end of its first summer, in
+      terms of body wet weight (g). Simulations account for changes in stream
+      temperature influenced by climate and wildfire, assuming that fish feeding
+      rates and food quality remain similar to their current values in the
+      future. Only stream reaches containing adequate habitat for juvenile
+      Chinook salmon are included (based on a model of underlying geomorphology,
       <a
         href="https://www.fs.usda.gov/pnw/pubs/journals/pnw_2007_burnett001.pdf"
         >described here</a
@@ -194,7 +194,7 @@ const renderPlot = () => {
     traces.push({
       type: 'scatter',
       mode: 'markers',
-      name: 'ERA',
+      name: 'ERA5',
       x: [1, 2, 3],
       y: [
         store.areaData['fishGrowth']['hist'][streamOrder]['ccsm']['0'][

--- a/components/HydroCharts.vue
+++ b/components/HydroCharts.vue
@@ -211,7 +211,7 @@ const metricYAxisLabels = {
   mean_annual_flow: 'Mean annual flow (m<sup>3</sup>/s)',
   MeanSummer: 'Mean summer flow (m<sup>3</sup>/s)',
   WinterMean: 'Mean winter flow (m<sup>3</sup>/s)',
-  LCV: 'Variation',
+  LCV: 'Coefficient of variation',
   LSkew: 'Skewness',
   LKurt: 'Kurtosis',
   AR1: 'Correlation',
@@ -245,10 +245,10 @@ const periodLabels = {
 }
 
 const streamStrings = {
-  '1': 'Headwater Streams (MAF ≤ 1m<sup>3</sup>/s)',
-  '2': 'Small Tributaries (1 < MAF ≤ 5m<sup>3</sup>/s)',
-  '3': 'Large Tributaries (5 < MAF ≤ 25m<sup>3</sup>/s)',
-  '4': 'Mainstem Rivers (MAF > 25m<sup>3</sup>/s)',
+  '1': 'Headwater Streams (MAF ≤ 1 m<sup>3</sup>/s)',
+  '2': 'Small Tributaries (1 < MAF ≤ 5 m<sup>3</sup>/s)',
+  '3': 'Large Tributaries (5 < MAF ≤ 25 m<sup>3</sup>/s)',
+  '4': 'Mainstem Rivers (MAF > 25 m<sup>3</sup>/s)',
 }
 
 const periodOptions = []

--- a/components/HydroCharts.vue
+++ b/components/HydroCharts.vue
@@ -3,7 +3,7 @@
     <h1 class="title">Hydrology</h1>
     <p>
       This section shows streamflow metrics and mean daily streamflow
-      (m<sup>3</sup>/s) projections compared with a historical dataset (ERA) for
+      (m<sup>3</sup>/s) projections compared with a historical dataset (ERA5 Reanalysis) for
       two climate models (NCAR-CCSM4; GFDL-CM3). Historic and future streamflow
       projections were calculated using the
       <a
@@ -248,7 +248,7 @@ const streamStrings = {
   '1': 'Headwater Streams (MAF ≤ 1m<sup>3</sup>/s)',
   '2': 'Small Tributaries (1 < MAF ≤ 5m<sup>3</sup>/s)',
   '3': 'Large Tributaries (5 < MAF ≤ 25m<sup>3</sup>/s)',
-  '4': 'Main Stem Rivers (MAF > 25m<sup>3</sup>/s)',
+  '4': 'Mainstem Rivers (MAF > 25m<sup>3</sup>/s)',
 }
 
 const periodOptions = []
@@ -291,7 +291,7 @@ const renderPlot = () => {
     statsTraces.push({
       type: 'scatter',
       mode: 'markers',
-      name: 'ERA',
+      name: 'ERA5',
       x: [1, 2, 3],
       y: [
         store.areaData['hydroStats'][streamOrder]['ccsm']['0'][
@@ -322,7 +322,7 @@ const renderPlot = () => {
       // Store a historical trace for each hydrograph stream order chart.
       hydrographTraces.push({
         mode: 'lines',
-        name: 'ERA',
+        name: 'ERA5',
         x: daysOfYear,
         y: hydrographPoints,
         marker: {

--- a/components/IntersectingAreas.vue
+++ b/components/IntersectingAreas.vue
@@ -21,9 +21,9 @@
         <li class="list-item">
           Alaska Fire Service (AFS) Fire Management Units
         </li>
-        <li class="list-item">Park and Conservation Units</li>
         <li class="list-item">Department of Defense (DOD) Lands</li>
-        <li class="list-item">Hydrologic Units Codes (HUCs)</li>
+        <li class="list-item">Hydrologic Unit Codes (HUCs)</li>
+        <li class="list-item">Park and Conservation Units</li>
       </ul>
     </div>
     <h5 class="title is-5" v-if="store.matchedAreaNames.length > 0">

--- a/components/StreamTempCharts.vue
+++ b/components/StreamTempCharts.vue
@@ -5,10 +5,10 @@
       This section summarizes future projections of ecologically relevant stream
       temperature metrics. Future projections are presented for two specific
       climate models (NCAR-CCSM4 and GFDL-CM3), compared with a historical
-      dataset (ERA). Results are presented as means for different stream orders
-      within the selected area of interest. Only stream reaches containing
-      adequate habitat for juvenile Chinook salmon are included (based on a
-      model of underlying geomorphology,
+      dataset (ERA5 Reanalysis). Results are presented as means for different
+      stream orders within the selected area of interest. Only stream reaches
+      containing adequate habitat for juvenile Chinook salmon are included
+      (based on a model of underlying geomorphology,
       <a
         href="https://www.fs.usda.gov/pnw/pubs/journals/pnw_2007_burnett001.pdf"
         >described here</a
@@ -182,7 +182,7 @@ const renderPlot = () => {
     traces.push({
       type: 'scatter',
       mode: 'markers',
-      name: 'ERA',
+      name: 'ERA5',
       x: [1, 2, 3],
       y: [
         store.areaData['streamTemp'][streamOrder]['ccsm']['0'][

--- a/pages/report.vue
+++ b/pages/report.vue
@@ -22,13 +22,14 @@
         <p>
           Here, we show possible future conditions for
           {{ availableDataString }}. These simulations use different Global
-          Circulation Models (GCMs)&mdash;such as the National Center for
-          Atmospheric Research Community Climate System Model 4.0 (NCAR CCSM4).
+          Circulation Models (GCMs) including the National Center for
+          Atmospheric Research Community Climate System Model 4.0 (NCAR CCSM4)
+          and Geophysical Fluid Dynamics Laboratory Coupled Model 3 (GFDL-CM3).
           Possible future conditions are compared with a historical dataset
-          (ERA), which uses reanalysis to combine historical observations with
-          short-range weather forecasts to create consistent and comprehensive
-          datasets of past weather and climate, filling gaps in the
-          observational record.
+          (ERA5 Reanalysis), which uses reanalysis to combine historical
+          observations with short-range weather forecasts to create consistent
+          and comprehensive datasets of past weather and climate, filling gaps
+          in the observational record.
         </p>
         <p>
           Results are based on Representative Concentration Pathway (RCP) 8.5, a
@@ -45,8 +46,7 @@
           order: a positive whole number used in geomorphology and hydrology to
           indicate the level of branching in a river system. First order streams
           are headwaters, second to third order are generally small and large
-          tributaries, and fourth order and above are generally main stem
-          rivers.
+          tributaries, and fourth order and above are generally mainstem rivers.
         </p>
         <p>
           Results include multiple models and scenarios, grouped by historic and

--- a/pages/report.vue
+++ b/pages/report.vue
@@ -23,7 +23,7 @@
           Here, we show possible future conditions for
           {{ availableDataString }}. These simulations use different Global
           Circulation Models (GCMs) including the National Center for
-          Atmospheric Research Community Climate System Model 4.0 (NCAR CCSM4)
+          Atmospheric Research Community Climate System Model 4.0 (NCAR-CCSM4)
           and Geophysical Fluid Dynamics Laboratory Coupled Model 3 (GFDL-CM3).
           Possible future conditions are compared with a historical dataset
           (ERA5 Reanalysis), which uses reanalysis to combine historical
@@ -40,8 +40,8 @@
         <p>
           Hydrology results are averaged by stream size class. Headwaters are
           streams with mean annual flows (MAF) &le; 1 m<sup>3</sup>/s, small
-          tributaries MAF &le; 5m<sup>3</sup>/s, large tributaries MAF &le;
-          25m<sup>3</sup>/s, and mainstem rivers MAF &gt; 25m<sup>3</sup>/s.
+          tributaries MAF &le; 5 m<sup>3</sup>/s, large tributaries MAF &le; 25
+          m<sup>3</sup>/s, and mainstem rivers MAF &gt; 25 m<sup>3</sup>/s.
           Stream temperature and fish growth data have been averaged by stream
           order: a positive whole number used in geomorphology and hydrology to
           indicate the level of branching in a river system. First order streams


### PR DESCRIPTION
This PR incorporates many small text edits based on pre-launch feedback, including:

- The "Types of places" list on the front page is now in alphabetical order.
- "Hydrologic Units Codes (HUCs)" has been corrected to "Hydrologic Unit Codes (HUCs)" (removed extra "s")
- The unnecessary `&mdash;` has been removed in the GCM description in the report page intro text, and both GCMs are now described instead of just NCAR-CCSM4.
- "ERA" has been updated to "ERA5 Reanalysis" throughout the report page body text, but is shortened to just "ERA5" in chart legends.
- Instances of "main stem" have been updated to "mainstem" (no space) for consistency.
- The app now uses consistent capitalization for "Chinook salmon" and "Arctic grayling", and the radio button options above the riparian fire index chart have been updated to use the full terms.
- The ellipsis from the "Go back, pick another place..." button has been removed.
- The "Coefficient of variation" chart y-axis label has been fixed to say the same thing instead of "Variation".
- Instances of values before units, like "5m<sup>3</sup>/s" have been updated across the board so there is always a space between the value and units, like "5 m<sup>3</sup>/s".