### PR TITLE
Disable map click if user arrived at report page from dropdown or permalink

### DIFF
--- a/components/Map.vue
+++ b/components/Map.vue
@@ -131,7 +131,11 @@ const addMapHandlers = () => {
   boundaryLayer = L.geoJSON(boundaryJson, {
     onEachFeature: function (feature, layer) {
       layer.on('click', e => {
-        if (marker == undefined && store.matchedAreaNames.length == 0) {
+        if (
+          marker == undefined &&
+          store.matchedAreaNames.length == 0 &&
+          route.params.hash == undefined
+        ) {
           let lat = e.latlng.lat
           let lng = e.latlng.lng
           store.$patch({


### PR DESCRIPTION
This PR fixes a bug that failed to disable the map's click functionality if the user arrived at the report page via:

- The dropdown menu on the front page
- A permalink URL

In other words, map click functionality had only been disabled if users arrived at the report page by clicking the map on the front page. If they never clicked the map to begin with, it wasn't being disabled.

To test, verify that clicking the map doesn't do anything when you arrive at the report page from the two methods listed above.