### PR TITLE
Change "ERA5" text and chart legends to "ERA-Interim"

### DIFF
--- a/components/FireImpactCharts.vue
+++ b/components/FireImpactCharts.vue
@@ -3,8 +3,8 @@
     <h1 class="title">Riparian Fire Index</h1>
     <p>
       This section shows projections for the mean riparian fire index, compared
-      with a historical dataset (ERA5 Reanalysis). Results are presented for
-      low, neutral, and high intensity wildfire scenarios for two specific
+      with a historical dataset (ERA-Interim Reanalysis). Results are presented
+      for low, neutral, and high intensity wildfire scenarios for two specific
       climate models (NCAR-CCSM4 and GFDL-CM3). The fire scenarios are a
       function of fire size, intensity, and fire weather.
     </p>
@@ -159,7 +159,7 @@ const renderPlot = () => {
     let trace = {
       type: 'scatter',
       mode: 'markers',
-      name: 'ERA5 (' + prefix + ' Intensity)',
+      name: 'ERA-Interim (' + prefix + ' Intensity)',
       x: [1 + xOffset, 2 + xOffset, 3 + xOffset],
       y: [fmoData['ccsm'][0][meanKey]],
       marker: {

--- a/components/FishGrowthCharts.vue
+++ b/components/FishGrowthCharts.vue
@@ -6,7 +6,7 @@
       under three
       <a @click="router.push({ name: 'fmo' })">fire management options</a>.
       Future projections are presented for two specific climate models
-      (NCAR-CCSM4 and GFDL-CM3), compared with a historical dataset (ERA5
+      (NCAR-CCSM4 and GFDL-CM3), compared with a historical dataset (ERA-Interim
       Reanalysis). Growth potential indicates how large a well-fed juvenile
       Chinook salmon could potentially grow by the end of its first summer, in
       terms of body wet weight (g). Simulations account for changes in stream
@@ -194,7 +194,7 @@ const renderPlot = () => {
     traces.push({
       type: 'scatter',
       mode: 'markers',
-      name: 'ERA5',
+      name: 'ERA-Interim',
       x: [1, 2, 3],
       y: [
         store.areaData['fishGrowth']['hist'][streamOrder]['ccsm']['0'][

--- a/components/HydroCharts.vue
+++ b/components/HydroCharts.vue
@@ -3,7 +3,7 @@
     <h1 class="title">Hydrology</h1>
     <p>
       This section shows streamflow metrics and mean daily streamflow
-      (m<sup>3</sup>/s) projections compared with a historical dataset (ERA5 Reanalysis) for
+      (m<sup>3</sup>/s) projections compared with a historical dataset (ERA-Interim Reanalysis) for
       two climate models (NCAR-CCSM4; GFDL-CM3). Historic and future streamflow
       projections were calculated using the
       <a
@@ -291,7 +291,7 @@ const renderPlot = () => {
     statsTraces.push({
       type: 'scatter',
       mode: 'markers',
-      name: 'ERA5',
+      name: 'ERA-Interim',
       x: [1, 2, 3],
       y: [
         store.areaData['hydroStats'][streamOrder]['ccsm']['0'][
@@ -322,7 +322,7 @@ const renderPlot = () => {
       // Store a historical trace for each hydrograph stream order chart.
       hydrographTraces.push({
         mode: 'lines',
-        name: 'ERA5',
+        name: 'ERA-Interim',
         x: daysOfYear,
         y: hydrographPoints,
         marker: {

--- a/components/StreamTempCharts.vue
+++ b/components/StreamTempCharts.vue
@@ -5,10 +5,10 @@
       This section summarizes future projections of ecologically relevant stream
       temperature metrics. Future projections are presented for two specific
       climate models (NCAR-CCSM4 and GFDL-CM3), compared with a historical
-      dataset (ERA5 Reanalysis). Results are presented as means for different
-      stream orders within the selected area of interest. Only stream reaches
-      containing adequate habitat for juvenile Chinook salmon are included
-      (based on a model of underlying geomorphology,
+      dataset (ERA-Interim Reanalysis). Results are presented as means for
+      different stream orders within the selected area of interest. Only stream
+      reaches containing adequate habitat for juvenile Chinook salmon are
+      included (based on a model of underlying geomorphology,
       <a
         href="https://www.fs.usda.gov/pnw/pubs/journals/pnw_2007_burnett001.pdf"
         >described here</a
@@ -182,7 +182,7 @@ const renderPlot = () => {
     traces.push({
       type: 'scatter',
       mode: 'markers',
-      name: 'ERA5',
+      name: 'ERA-Interim',
       x: [1, 2, 3],
       y: [
         store.areaData['streamTemp'][streamOrder]['ccsm']['0'][

--- a/pages/report.vue
+++ b/pages/report.vue
@@ -26,7 +26,7 @@
           Atmospheric Research Community Climate System Model 4.0 (NCAR-CCSM4)
           and Geophysical Fluid Dynamics Laboratory Coupled Model 3 (GFDL-CM3).
           Possible future conditions are compared with a historical dataset
-          (ERA5 Reanalysis), which uses reanalysis to combine historical
+          (ERA-Interim Reanalysis), which uses reanalysis to combine historical
           observations with short-range weather forecasts to create consistent
           and comprehensive datasets of past weather and climate, filling gaps
           in the observational record.


### PR DESCRIPTION
This PR fixes all "ERA5" references in the report text and chart legends to say "ERA-Interim" instead since ERA-Interim was used to produce the various datasets.