### PR TITLE
Update Umami script URL to v2 version

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -22,7 +22,7 @@ export default defineNuxtConfig({
     head: {
       script: [
         {
-          src: 'https://umami.snap.uaf.edu/umami.js',
+          src: 'https://umami.snap.uaf.edu/script.js',
           'data-website-id': '0d96da3f-f9c7-4f69-946d-848d38c0b5d3',
           'data-do-not-track': 'true',
           'data-domains': 'snap.uaf.edu',


### PR DESCRIPTION
This PR updates the Umami script URL to work with Umami v2. I.e., `umami.js` was changed to `script.js`.

You will need the Umami v2 Vagrant VM to test against. If you do not already have this set up, refer to the Vagrant instructions in https://github.com/ua-snap/nccwsc-projects/pull/154.

With the Vagrant VM running, and assuming Umami's port is forwarded to port 9999 of the host, simply change the Umami config in `nuxt.config.js` to:

```
{
  src: 'http://localhost:9999/script.js',
  'data-website-id': '0d96da3f-f9c7-4f69-946d-848d38c0b5d3',
  'data-do-not-track': 'true',
  // 'data-domains': 'snap.uaf.edu',
  async: 'true',
  defer: 'true',
},
```

Then run the webapp locally and verify that your traffic shows up here: http://localhost:9999/websites/0d96da3f-f9c7-4f69-946d-848d38c0b5d3