### PR TITLE
Changes the base map from USGS to SNAP's retina base map

### DIFF
--- a/components/Map.vue
+++ b/components/Map.vue
@@ -92,12 +92,11 @@ onMounted(() => {
   ])
 
   var baseLayer = new L.tileLayer.wms(
-    'https://basemap.nationalmap.gov/arcgis/services/USGSTopo/MapServer/WMSServer',
+    'https://gs.mapventure.org/geoserver/atlas_mapproxy/wms',
     {
-      layers: '0',
+      layers: 'atlas_mapproxy:alaska_osm_retina',
       format: 'image/png',
       transparent: true,
-      attribution: 'USGS',
       baseLayer: true,
     }
   )


### PR DESCRIPTION
This PR changes the base map from the USGS map to the SNAP retina base map as the USGS map has apparently been removed. 

Closes #144 