### PR TITLE
Construct all GeoServer URLs from GEOSERVER_URL environment variable (and fix GeoServer URLs)

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-GEOSERVER_URL=https://gs.mapventure.org/geoserver/fish_and_fire/ows?service=WFS&version=1.0.0&request=GetFeature&typeName=fish_and_fire%3AAOIs&outputFormat=application%2Fjson
+GEOSERVER_URL=https://gs.earthmaps.io/geoserver

--- a/components/Map.vue
+++ b/components/Map.vue
@@ -102,7 +102,9 @@ onMounted(() => {
     }
   )
 
-  shadowMask = new L.tileLayer.wms('https://gs.mapventure.org/geoserver/wms', {
+  const runtimeConfig = useRuntimeConfig()
+  let geoserverUrl = runtimeConfig.public.geoserverUrl
+  shadowMask = new L.tileLayer.wms(geoserverUrl + '/wms', {
     transparent: true,
     format: 'image/png',
     version: '1.3.0',

--- a/stores/store.ts
+++ b/stores/store.ts
@@ -1,5 +1,9 @@
 import { defineStore } from 'pinia'
 import hash_map from '~/assets/hash_map.json'
+const runtimeConfig = useRuntimeConfig()
+const geoserverWfsUrl =
+  runtimeConfig.public.geoserverUrl +
+  '/fish_and_fire/ows?service=WFS&version=1.0.0&request=GetFeature&typeName=fish_and_fire%3AAOIs&outputFormat=application%2Fjson'
 
 export const useStore = defineStore('store', () => {
   const areas = ref([])
@@ -22,10 +26,9 @@ export const useStore = defineStore('store', () => {
         PARK: 'Park and Conservation Units',
       }
 
-      const runtimeConfig = useRuntimeConfig()
-      let geoserverUrl =
-        runtimeConfig.public.geoserverUrl + '&PropertyName=(AOI_Name_,Category)'
-      let response = await $fetch(geoserverUrl)
+      let geoserverPropertyUrl =
+        geoserverWfsUrl + '&PropertyName=(AOI_Name_,Category)'
+      let response = await $fetch(geoserverPropertyUrl)
       if (response != undefined) {
         response.features.forEach(area => {
           let category = area.properties['Category']
@@ -55,15 +58,14 @@ export const useStore = defineStore('store', () => {
   const fetchIntersectingAreas = async (lat, lon) => {
     try {
       let areas = []
-      const runtimeConfig = useRuntimeConfig()
-      let geoserverUrl =
-        runtimeConfig.public.geoserverUrl +
+      let geoserverIntersectsUrl =
+        geoserverWfsUrl +
         '&cql_filter=INTERSECTS(the_geom,POINT(' +
         lon +
         ' ' +
         lat +
         '))'
-      let response = await $fetch(geoserverUrl)
+      let response = await $fetch(geoserverIntersectsUrl)
       if (response != undefined) {
         intersectingAreas.value = response.features
       }
@@ -102,13 +104,12 @@ export const useStore = defineStore('store', () => {
     let aoi = hash_map[hash.value]
 
     try {
-      const runtimeConfig = useRuntimeConfig()
-      let geoserverUrl =
-        runtimeConfig.public.geoserverUrl +
+      let geoserverFilterUrl =
+        geoserverWfsUrl +
         "&cql_filter=AOI_Name_='" +
         encodeURIComponent(aoi) +
         "'"
-      let response = await $fetch(geoserverUrl)
+      let response = await $fetch(geoserverFilterUrl)
       if (response != undefined) {
         resultGeom.value = response.features[0].geometry
       }


### PR DESCRIPTION
This PR updates all GeoServer URLs to use `gs.earthmaps.io` instead of `gs.mapventure.org`. I was almost able to accomplish this just by setting the `GEOSERVER_URL` environment variable, but I discovered that I had previously added a hard-coded GeoServer URL for the `shadowMask`, which is loaded over WMS (instead of WFS like the rest of the GeoServer URLs).

So, this PR also rewires things so that all GeoServer URLs are constructed from the same `GEOSERVER_URL` environment variable. This will make it easier to change the GeoServer domain in the future if necessary.

The production webapp was broken without this change, so I've gone ahead and built & deployed the webapp from this branch. To test, view the production webapp at https://snap.uaf.edu/tools/fish-and-fire/ and verify that all GeoServer-related functionality is working:

- The dropdown menu on the front page is populated with areas of interest to select from
- A shadow mask is displayed on the front page map to show the clickable region
- Clicking the map fetches and displays all areas intersecting the point you clicked
- Selecting an area of interest takes you to a report page and displays the selected area of interest by itself on the larger map above